### PR TITLE
Fix/ols4 search

### DIFF
--- a/dist_plainjs/manually_maintained_types.d.ts
+++ b/dist_plainjs/manually_maintained_types.d.ts
@@ -224,6 +224,7 @@ declare global {
       initialItemsPerPage?: number;
       itemsPerPageOptions?: number[];
       targetLink?: string;
+      useLegacy?: boolean;
     } & Partial<Omit<EuiCardProps, "layout">>
     )=>void
   }

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -353,7 +353,7 @@ export type SearchBarWidgetProps = Omit<EuiSuggestProps, "suggestions" | "onChan
     onSearchValueChange: (suggestion: string) => void;
 };
 
-export type SearchResultsListWidgetProps = Partial<Omit<EuiCardProps, "layout">> & ApiObj & TargetLinkObj & ParameterObj & {
+export type SearchResultsListWidgetProps = Partial<Omit<EuiCardProps, "layout">> & ApiObj & TargetLinkObj & ParameterObj & UseLegacyObj &{
     /**
      * The terms to search. By default, the search is performed over term labels, synonyms, descriptions, identifiers and annotation properties.
      */

--- a/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbPresentation.tsx
+++ b/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbPresentation.tsx
@@ -7,7 +7,7 @@ function BreadcrumbPresentation(props: BreadcrumbPresentationProps) {
     <>
         <span>
           <EuiBadge color={props.colorFirst || "primary"}>
-            {props.ontologyName.toUpperCase()}
+            {props.ontologyName ? props.ontologyName.toUpperCase() : "No ontology name available"}
           </EuiBadge>
           {" > "}
           <EuiBadge color={props.colorSecond || "success"}>

--- a/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.stories.tsx
+++ b/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.stories.tsx
@@ -13,5 +13,6 @@ export {
     SearchResultsListNFDI4Health,
     ErrorSearchResultsList,
     TibNFDI4CHEM,
-    TibDataPlant
+    TibDataPlant,
+    SearchResultsListOls4
 } from "./SearchResultsListWidgetStories"

--- a/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.tsx
+++ b/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.tsx
@@ -33,6 +33,7 @@ function SearchResultsListWidget(props: SearchResultsListWidgetProps) {
         itemsPerPageOptions = DEFAULT_PAGE_SIZE_OPTIONS,
         targetLink,
         preselected,
+        useLegacy = true,
         ...rest
     } = props;
     const olsApi = new OlsApi(api);
@@ -130,20 +131,31 @@ function SearchResultsListWidget(props: SearchResultsListWidgetProps) {
                     if (response["facet_counts"] && response["facet_counts"]["facet_fields"]) {
                         if (response["facet_counts"]["facet_fields"]["type"]) {
                             updateFilterOptions(
-                                filterByTypeOptions,
-                                response["facet_counts"]["facet_fields"]["type"],
-                                setFilterByTypeOptions,
-                                (currentValue: string) => `${currentValue[0].toUpperCase()}${currentValue.slice(1)}`
+                              filterByTypeOptions,
+                              response["facet_counts"]["facet_fields"]["type"],
+                              setFilterByTypeOptions,
+                              (currentValue: string) => `${currentValue[0].toUpperCase()}${currentValue.slice(1)}`
                             );
                         }
-                        if (response["facet_counts"]["facet_fields"]["ontology_name"]) {
-                            updateFilterOptions(
-                                filterByOntologyOptions,
-                                response["facet_counts"]["facet_fields"]["ontology_name"],
-                                setFilterByOntologyOptions,
-                                (currentValue: string) => currentValue.toUpperCase()
-                            );
-                        }
+                        if (useLegacy) {
+                            if (response["facet_counts"]["facet_fields"]["ontology_name"]) {
+                                updateFilterOptions(
+                                  filterByOntologyOptions,
+                                  response["facet_counts"]["facet_fields"]["ontology_name"],
+                                  setFilterByOntologyOptions,
+                                  (currentValue: string) => currentValue.toUpperCase()
+                                );
+                            }
+                        } else {
+                                if (response["facet_counts"]["facet_fields"]["ontologyId"]) {
+                                    updateFilterOptions(
+                                      filterByOntologyOptions,
+                                      response["facet_counts"]["facet_fields"]["ontologyId"],
+                                      setFilterByOntologyOptions,
+                                      (currentValue: string) => currentValue.toUpperCase()
+                                    );
+                                }
+                            }
                     }
 
                     setTotalItems(response["response"]["numFound"]);

--- a/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.tsx
+++ b/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.tsx
@@ -220,6 +220,7 @@ function SearchResultsListWidget(props: SearchResultsListWidgetProps) {
                 singleSelection={true}
                 hasShortSelectedLabel={true}
                 placeholder={"Search"}
+                parameter={parameter}
                 preselected={preselected}
             />
 

--- a/src/components/widgets/SearchResultsListWidget/SearchResultsListWidgetHTML.stories.ts
+++ b/src/components/widgets/SearchResultsListWidget/SearchResultsListWidgetHTML.stories.ts
@@ -31,6 +31,7 @@ window['SemLookPWidgets'].createSearchResultsList(
         initialItemsPerPage:${args.initialItemsPerPage},
         itemsPerPageOptions:[${args.itemsPerPageOptions}],
         targetLink:"${args.targetLink}",
+        useLegacy:"${args.useLegacy}",
     },
     document.querySelector('#search_results_list_widget_container_${num}')
 )
@@ -44,5 +45,8 @@ window['SemLookPWidgets'].createSearchResultsList(
 export {
     SearchResultsListSafety,
     SearchResultsListNFDI4Health,
-    ErrorSearchResultsList
+    ErrorSearchResultsList,
+    TibNFDI4CHEM,
+    TibDataPlant,
+    SearchResultsListOls4
 } from "./SearchResultsListWidgetStories"

--- a/src/components/widgets/SearchResultsListWidget/SearchResultsListWidgetStories.ts
+++ b/src/components/widgets/SearchResultsListWidget/SearchResultsListWidgetStories.ts
@@ -39,7 +39,7 @@ export const SearchResultsListSafety = {
         api: "https://semanticlookup.zbmed.de/api/",
         query: "d*",
         targetLink: "",
-        parameter: "collection=safety",
+        parameter: "collection=safety&fieldList=description,label,iri,ontology_name,type,short_form",
     }
 };
 
@@ -48,7 +48,7 @@ export const SearchResultsListNFDI4Health = {
         api: "https://semanticlookup.zbmed.de/api/",
         query: "d*",
         targetLink: "",
-        parameter: "collection=nfdi4health",
+        parameter: "collection=nfdi4health&fieldList=description,label,iri,ontology_name,type,short_form",
         preselected: [{ label: "diabetes" }],
         useLegacy: true
     }
@@ -66,7 +66,7 @@ export const ErrorSearchResultsList = {
 export const TibNFDI4CHEM = {
     args: {
         api: "https://service.tib.eu/ts4tib/api/",
-        parameter: "classification=NFDI4CHEM&schema=collection",
+        parameter: "classification=NFDI4CHEM&schema=collection&fieldList=description,label,iri,ontology_name,type,short_form",
         query: "assay",
         targetLink: "",
     }
@@ -75,7 +75,7 @@ export const TibNFDI4CHEM = {
 export const TibDataPlant = {
     args: {
         api: "https://service.tib.eu/ts4tib/api/",
-        parameter: "classification=DataPLANT&schema=collection",
+        parameter: "classification=DataPLANT&schema=collection&fieldList=description,label,iri,ontology_name,type,short_form",
         query: "agriculture",
         targetLink: "",
     }

--- a/src/components/widgets/SearchResultsListWidget/SearchResultsListWidgetStories.ts
+++ b/src/components/widgets/SearchResultsListWidget/SearchResultsListWidgetStories.ts
@@ -21,6 +21,9 @@ export const SearchResultsListWidgetStoryArgTypes = {
     parameter: {
         type: { required: false }
     },
+    useLegacy: {
+        type: { required: false }
+    }
 }
 
 export const SearchResultsListWidgetStoryArgs = {
@@ -47,6 +50,7 @@ export const SearchResultsListNFDI4Health = {
         targetLink: "",
         parameter: "collection=nfdi4health",
         preselected: [{ label: "diabetes" }],
+        useLegacy: true
     }
 };
 
@@ -74,5 +78,15 @@ export const TibDataPlant = {
         parameter: "classification=DataPLANT&schema=collection",
         query: "agriculture",
         targetLink: "",
+    }
+};
+
+export const SearchResultsListOls4 = {
+    args: {
+        api: "https://www.ebi.ac.uk/ols4/api/",
+        query: "*",
+        targetLink: "/",
+        parameter: "",
+        useLegacy: false
     }
 };


### PR DESCRIPTION
Differences on OLS3/OLS4 API facet keys:

OLS3: response["facet_counts"]["facet_fields"]["ontology_name"]
OLS4: response["facet_counts"]["facet_fields"]["ontologyId"]

-> Added useLegacy parameter and condition in useQuery API call.

Also fixed minor bug in BreadcrumbPresentation.