### PR TITLE
Detect cycles

### DIFF
--- a/src/api/OlsApi.ts
+++ b/src/api/OlsApi.ts
@@ -875,27 +875,38 @@ export class OlsApi implements HierarchyBuilder{
     }
     /* --- */
 
-    function createTreeNode(entityData: EntityDataForHierarchy, childRelationToParent?: string): TreeNode {
+    function createTreeNode(entityData: EntityDataForHierarchy, cycleCheck: Set<string>, childRelationToParent?: string): TreeNode {
+      cycleCheck.add(entityData.iri); // add current entity to cycle check set
+
       const node = new TreeNode(entityData);
       node.childRelationToParent = childRelationToParent;
       const children = parentChildRelations.get(entityData.iri) || [];
 
       for(const child of children) {
+        if(cycleCheck.has(child.childIri)) {
+          // cyclic tree, skip cycle
+          console.error(`Cyclic tree at entity "${child.childIri}".`);
+          continue;
+        }
+
         const childData = entitiesData.get(child.childIri);
-        if(childData != undefined) node.addChild(createTreeNode(childData, child.childRelationToParent));
+        if(childData != undefined) node.addChild(createTreeNode(childData, cycleCheck, child.childRelationToParent));
       }
 
       if(node.loadedChildren.length > 0) node.expanded = true;
 
+      cycleCheck.delete(entityData.iri);
       return node;
     }
+
+    const cycleCheck: Set<string> = new Set<string>(); // Contains iris of all entities that have occurred within the current recursion branch. Is used to check for cycles.
 
     return new Hierarchy({
       parentChildRelations: parentChildRelations,
       entitiesData: entitiesData,
       allChildrenPresent: allChildrenPresent,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      roots: rootEntities.map((rootEntity) => createTreeNode(entitiesData.get(rootEntity)!)).sort((a,b) => (a.entityData.label || a.entityData.iri).localeCompare(b.entityData.label || b.entityData.iri)),
+      roots: rootEntities.map((rootEntity) => createTreeNode(entitiesData.get(rootEntity)!, cycleCheck)).sort((a,b) => (a.entityData.label || a.entityData.iri).localeCompare(b.entityData.label || b.entityData.iri)),
       api: new OlsApi(this.axiosInstance.getUri()),
       ontologyId: ontologyId,
       includeObsoleteEntities: includeObsoleteEntities,

--- a/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.stories.tsx
@@ -15,7 +15,6 @@ export default {
 };
 
 export {
-    BreadcrumbWidgetExample,
     SelectingDefiningOntology,
     DefiningOntologyUnavailable,
     ErrorBreadcrumbWidget

--- a/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidgetHTML.stories.ts
+++ b/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidgetHTML.stories.ts
@@ -43,7 +43,6 @@ window['SemLookPWidgets'].createBreadcrumb(
 }
 
 export {
-    BreadcrumbWidgetExample,
     SelectingDefiningOntology,
     DefiningOntologyUnavailable,
     ErrorBreadcrumbWidget

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidget.stories.tsx
@@ -20,5 +20,6 @@ export {
     IndividualRoots,
     LargeHierarchy,
     SkosHierarchy,
+    SagePubHierarchy,
     OntoportalHierarchy
 } from "./HierarchyWidgetStories";

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidget.tsx
@@ -148,7 +148,7 @@ function HierarchyWidget(props: HierarchyWidgetProps) {
 
     function renderTreeNode(hierarchy: Hierarchy, node: TreeNode, drawLine?: boolean) {
         return (
-            <span>
+            <span key={randomString()}>
                 <EuiText>
                     {
                         !node.entityData.hasChildren ?

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidget.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidget.tsx
@@ -30,13 +30,13 @@ function TreeLink(props: {entityData: EntityDataForHierarchy, childRelationToPar
             <span className={props.highlight ? "highlight" : undefined}>
                 {props.childRelationToParent == "http://purl.obolibrary.org/obo/BFO_0000050" &&
                     <>
-                        <span className="surroundCircle">&nbsp;P&nbsp;</span>
+                        <span style={{marginInlineStart: "1.5px", marginTop: "2.5px"}} className="surroundCircle">&nbsp;P&nbsp;</span>
                         &nbsp;
                     </>
                 }
                 {props.childRelationToParent == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
                     <>
-                        <span className="surroundCircle">I</span>
+                        <span style={{marginInlineStart: "1.5px", marginTop: "2.5px"}} className="surroundCircle">I</span>
                         &nbsp;
                     </>
                 }
@@ -148,33 +148,42 @@ function HierarchyWidget(props: HierarchyWidgetProps) {
 
     function renderTreeNode(hierarchy: Hierarchy, node: TreeNode, drawLine?: boolean) {
         return (
-            <span key={randomString()}>
+            <div key={randomString()}>
                 <EuiText>
-                    {
-                        !node.entityData.hasChildren ?
-                            <EuiIcon type={"empty"}/> :
-                            <button onClick={() => {toggleNode(node)}}>
-                                <EuiIcon type={node.expanded ? "arrowDown" : "arrowRight"}/>
-                            </button>
-                    }
-                    &nbsp;
-                    <TreeLink entityData={node.entityData} childRelationToParent={node.childRelationToParent} ontologyId={hierarchy.ontologyId} entityType={hierarchy.entityType} onNavigateToEntity={onNavigateToEntity} onNavigateToOntology={onNavigateToOntology} highlight={node.entityData.iri == hierarchy?.mainEntityIri}/>
-                    &nbsp;
-                    {node.entityData.numDescendants != undefined && node.entityData.numDescendants > 0 && <span style={{color: "gray"}}>({node.entityData.numDescendants.toLocaleString()})</span>}
+                    <div style={{height: "24px"}}>
+                      <div style={{position: "relative", borderLeft: "1px dotted black", borderBottom: "1px dotted black", width: "12px", height: "16px", left: "5.5px", top: "-1px"}}></div>
+                      <div style={{position: "relative", borderLeft: drawLine ? "1px dotted black":"", width: "12px", height: "9px", left: "5.5px", top: "0px"}}></div>
+                      <div style={{position: "relative", top: "-22px"}}>
+                          <span>{
+                              !node.entityData.hasChildren ?
+                                  <EuiIcon type={"empty"}/> :
+                                  <button style={{}} onClick={() => {toggleNode(node)}}>
+                                      <EuiIcon type={node.expanded ? "arrowDown" : "arrowRight"} size={"s"}/>
+                                  </button>
+                          }</span>
+
+                          &nbsp;
+                          <TreeLink entityData={node.entityData} childRelationToParent={node.childRelationToParent} ontologyId={hierarchy.ontologyId} entityType={hierarchy.entityType} onNavigateToEntity={onNavigateToEntity} onNavigateToOntology={onNavigateToOntology} highlight={node.entityData.iri == hierarchy?.mainEntityIri}/>
+                          &nbsp;
+                          {node.entityData.numDescendants != undefined && node.entityData.numDescendants > 0 && <span style={{color: "gray"}}>({node.entityData.numDescendants.toLocaleString()})</span>}
+                      </div>
+                    </div>
+
+
                 </EuiText>
                 {node.expanded &&
-                    <ul style={{marginBlockEnd: "0", marginInlineStart: "0.5rem"}}>
+                    <ul style={{marginBlockEnd: "0", marginInlineStart: "5.5px"}}>
                         {node.loading ?
-                            <EuiLoadingSpinner/> :
+                            <EuiLoadingSpinner style={{position: "relative", left: "13px", top: "5px"}}/> :
                             node.loadedChildren.map((child, idx) => {
-                                return <div key={randomString()} style={{borderLeft: drawLine ? "2px dotted grey":"", paddingLeft: "1rem"}}>
+                                return <div key={randomString()} style={{borderLeft: drawLine ? "1px dotted black":"", paddingLeft: "1rem"}}>
                                     {renderTreeNode(hierarchy, child, idx < node.loadedChildren.length - 1)}
                                 </div>
                             })
                         }
                     </ul>
                 }
-            </span>
+            </div>
         );
     }
 

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidgetStories.ts
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidgetStories.ts
@@ -172,7 +172,8 @@ export const IncludeObsoleteEntities = {
         iri: "",
         entityType: "class",
         ontologyId: "uberon",
-        includeObsoleteEntities: true
+        includeObsoleteEntities: true,
+        useLegacy: true
     }
 };
 
@@ -183,6 +184,7 @@ export const PropertyRoots = {
         iri: "",
         entityType: "property",
         ontologyId: "bco",
+        useLegacy: true
     }
 };
 
@@ -214,6 +216,15 @@ export const SkosHierarchy = {
         ontologyId: "yso",
     }
 };
+
+export const SagePubHierarchy = {
+    args: {
+        apiUrl: "https://concepts.sagepub.com/vocabularies/rest/v1/",
+        backendType: "skosmos",
+        iri: "https://concepts.sagepub.com/social-science/concept/economic_forecasting",
+        ontologyId: "social-science"
+    }
+}
 
 export const OntoportalHierarchy = {
     args: {

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidgetsHTML.stories.ts
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidgetsHTML.stories.ts
@@ -58,5 +58,6 @@ export {
     IndividualRoots,
     LargeHierarchy,
     SkosHierarchy,
+    SagePubHierarchy,
     OntoportalHierarchy
 } from "./HierarchyWidgetStories"

--- a/src/model/ols4-model/OLS4Entity.ts
+++ b/src/model/ols4-model/OLS4Entity.ts
@@ -11,12 +11,12 @@ export abstract class OLS4Entity extends OLS4Thing implements Entity{
   abstract getEquivalents(): Reified<any>[];
 
   isCanonical(): boolean {
-    return this.properties["isDefiningOntology"] === true;
+    return this.properties["isDefiningOntology"]
   }
 
   isDeprecated(): boolean {
     return (
-      this.properties["http://www.w3.org/2002/07/owl#deprecated"] === "true"
+      this.properties["http://www.w3.org/2002/07/owl#deprecated"]
     );
   }
 
@@ -48,11 +48,11 @@ export abstract class OLS4Entity extends OLS4Thing implements Entity{
   }
 
   hasDirectChildren(): boolean {
-    return this.properties["hasDirectChildren"] === "true";
+    return this.properties["hasDirectChildren"];
   }
 
   hasHierarchicalChildren(): boolean {
-    return this.properties["hasHierarchicalChildren"] === "true";
+    return this.properties["hasHierarchicalChildren"];
   }
 
   hasChildren(): boolean {


### PR DESCRIPTION
- fixes vanished arrows on HierarchyWidget
- introduces cycle detection in hierarchy trees. cyclic branches are not expanded anymore, preventing unlimited recursion. a warning is printed on console to inform about the cyclic branch, which could be a mistake in the terminology service
- other minor issues were addressed