### PR TITLE
Feat/autocomplete with metadatawidget

### DIFF
--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -10,11 +10,14 @@ import {
   EuiHighlight,
   EuiHealth,
   EuiProvider,
-  EuiIcon
+  EuiIcon,
+  EuiPanel,
+  EuiFlexGroup
 } from "@elastic/eui";
 import { QueryClient, QueryClientProvider, useQuery } from "react-query";
 import { AutocompleteWidgetProps } from "../../../app/types";
 import { BreadcrumbPresentation } from "../MetadataWidget/BreadcrumbWidget/BreadcrumbPresentation";
+import { MetadataWidget } from "../MetadataWidget";
 
 /**
  * A React component to provide Autosuggestion based on SemLookP.
@@ -211,6 +214,19 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
     }
   );
 
+  const createToolTipContent = (iri) =>
+    <EuiFlexGroup style={{ color: "black" }}>
+      <EuiPanel>
+        <MetadataWidget
+          api={api}
+          iri={iri}
+          hierarchyTab={false}
+          crossRefTab={false}
+          terminologyInfoTab={false}
+        />
+      </EuiPanel>
+    </EuiFlexGroup>
+
   /**
    * fetches new options when searchValue changes
    */
@@ -247,7 +263,13 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
                   short_form: selection.getShortForm(),
                   description: selection.getDescription(),
                   source: selection.getApiSourceName(),
-                  source_url: selection.getApiSourceEndpoint()
+                  source_url: selection.getApiSourceEndpoint(),
+                },
+                toolTipContent: createToolTipContent(
+                  selection.getIri()
+                ),
+                toolTipProps: {
+                  css: {maxWidth: "none", maxHeight: "none"},
                 }
               })
             ));

--- a/src/components/widgets/MetadataWidget/MetadataWidget.tsx
+++ b/src/components/widgets/MetadataWidget/MetadataWidget.tsx
@@ -111,16 +111,20 @@ function MetadataWidget(props: MetadataWidgetProps) {
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
+          {data.entity.getDescription() &&
           <EuiFlexItem style={{ maxWidth: 600 }}>
             <DescriptionPresentation
               description={data.entity.getDescription()}
             />
           </EuiFlexItem>
+          }
 
+          {data.ontoList && data.ontoList.length > 0 &&
           <div style={{margin: "0 12px 0", maxWidth: 600 }}>
               <EntityOntoListPresentation iri={props.iri} label={data.entity.getLabel() || ""} ontolist={data.ontoList} entityType={entityType || data.entity.getType() as EntityTypeName} onNavigateToOntology={onNavigateToOntology} />
               <EntityDefinedByPresentation iri={props.iri} ontolist={data.definedBy} label={data.entity.getLabel() || ""} entityType={entityType || data.entity.getType() as EntityTypeName} onNavigateToOntology={onNavigateToOntology} />
           </div>
+          }
 
           <EuiFlexItem>
               <TabPresentation


### PR DESCRIPTION
1) **AutocompleteWidget**: The hover information of the option doesn't have any design. Add the MetadataWidget for additional and styled information. Doesn't include entity source or source URL yet (should we add this information to the MetadataWidget?). Unstyled hover information still present - should be removed after adding the source information to the MetadataWidget - do not merge this PR before.

Caveat: Not accessible - no links can be clicked and only one tab can be displayed.

Solves #127

![image](https://github.com/user-attachments/assets/c596e4a3-6b64-4549-8c46-4541ded1134c)

2) **MetadataWidget**: Data not available will result in a blank. Use conditionals to avoid spaces.

Before:
![image](https://github.com/user-attachments/assets/b7239392-ff36-4522-9894-13f6663e56ce)

After:
![image](https://github.com/user-attachments/assets/ade5c160-8408-4d45-a15b-663ddc0abe52)


Solves #176