### PR TITLE
docs: add git commit message template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,12 @@
+<build|ci|docs|feat|fix|perf|refactor|test>(widgetname[lowercase, optional]): <description> (in present tense. Not capitalized. No period at the end)
+
+<motivation for the change>
+
+<information about breaking changes, deprecations, references to GitHub issues>
+
+
+#(Note that the BREAKING CHANGE: token must be in the footer of the commit)
+
+#HINT: Parameter renaming is a BREAKING CHANGE! Type changes of parameter functions are BREAKING CHANGES!
+
+#HINT 2: Don't use Emoji in commit messages (e.g. 🐛), because it breaks semantic versioning!

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ Do a `npm run build:plainJS` before testing the HTML Storybook.
 
 ### Commit Message Formatting
 
+**Note:** There is a commit message template named **.gitmessage** inside this repo which you can use as your template locally by running:
+
+    git config --local commit.template .gitmessage
+
+
 This project uses [Semantic Release](https://semantic-release.gitbook.io/semantic-release/), i.e. the CI/CD pipeline
 analyzes the commit messages and automatically performs a release depending on the format. 
 Release notes are automatically created from commit messages.  


### PR DESCRIPTION
It is better to make a git commit message to help the contributor know how to write a commit message with regard to the semantic versioning. In particular important for people who use command line for their git tasks.