### PR TITLE
fix(hierarchy): add required OLS3 viewMode parameter

### DIFF
--- a/src/api/OlsApi.ts
+++ b/src/api/OlsApi.ts
@@ -608,7 +608,7 @@ export class OlsApi implements HierarchyBuilder {
   }
 
   public async getJSTree(iri: string, entityType: EntityTypeName, ontologyId: string): Promise<JSTreeNode[]> {
-    return await this.makeCall(`${getEntityInOntologySuffix(ontologyId, entityType, iri, true)}/jstree`, { params: { size: "1000" } }, true);
+    return await this.makeCall(`${getEntityInOntologySuffix(ontologyId, entityType, iri, true)}/jstree`, { params: { size: "1000", viewMode: "All" } }, true);
   }
 
   // TODO: Do we want the same behavior as EMBL EBI (e.g. not getting instances for classes if entityType != "individual")?

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidget.stories.tsx
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidget.stories.tsx
@@ -31,5 +31,6 @@ export {
     LargeHierarchy,
     SkosHierarchy,
     SagePubHierarchy,
-    OntoportalHierarchy
+    OntoportalHierarchy,
+    OLS3Hierarchy
 } from "./HierarchyWidgetStories";

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidgetStories.ts
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidgetStories.ts
@@ -218,3 +218,14 @@ export const OntoportalHierarchy = {
         apiKey: ""
     }
 }
+
+export const OLS3Hierarchy = {
+    args: {
+        apiUrl: globals.ZBMED_OLS_API_ENDPOINT,
+        backendType: "ols",
+        iri: "http://www.ebi.ac.uk/efo/EFO_0000400",
+        entityType: "class",
+        ontologyId: "efo",
+        useLegacy: true,
+    }
+};

--- a/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidgetsHTML.stories.ts
+++ b/src/components/widgets/MetadataWidget/TabWidget/HierarchyWidgetSemLookP/HierarchyWidgetsHTML.stories.ts
@@ -65,5 +65,6 @@ export {
     LargeHierarchy,
     SkosHierarchy,
     SagePubHierarchy,
-    OntoportalHierarchy
+    OntoportalHierarchy,
+    OLS3Hierarchy
 } from "./HierarchyWidgetStories"


### PR DESCRIPTION
Without the viewMode parameter there is no json response. Added the parameter to the API call.

Closes #194

![image](https://github.com/user-attachments/assets/04b9f92b-b864-4151-8566-368723ce0f16)
