### PR TITLE
feat(types): export input prop types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ts4nfdi/terminology-service-suite",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ts4nfdi/terminology-service-suite",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
         "@elastic/datemath": "^5.0.3",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./components";
+export * from "./app"


### PR DESCRIPTION
Export the input prop types so they don't need to be defined in a Next.js consumer app.

Closes #211
Related to #198 