### PR TITLE
Fix/searchresults ssr

### DIFF
--- a/src/components/widgets/SearchResultsListWidget/MetadataCompact.tsx
+++ b/src/components/widgets/SearchResultsListWidget/MetadataCompact.tsx
@@ -34,6 +34,7 @@ function MetadataCompact(props: MetadataCompactProps) {
             : targetLink + "ontologies/" + result.ontology_name
           : undefined
       }
+      titleElement={"span"}
       title={
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>

--- a/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.tsx
+++ b/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.tsx
@@ -407,7 +407,7 @@ function SearchResultsListWidget(props: SearchResultsListWidgetProps) {
 
             {searchResults &&
               searchResults.map((result: any) => (
-                <React.Fragment key={result.id}>
+                <React.Fragment key={result.iri+result.ontology_name+result.type}>
                   <MetadataCompact
                     api={api}
                     result={result}


### PR DESCRIPTION
fix(searchresults): solve ssr warnings - The title prop of EuiCard somehow uses `<p>` elements. But `<div>` and `<h2>` elements (which are used to compose the title) can't appear as descendants of `<p>`.

fix(searchresults): solve ssr warnings - each child in a list should have a unique key prop. the "result.id" is not unique.

Closes #234