### PR TITLE
SSR BreadcrumbWidget

### DIFF
--- a/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbPresentation.tsx
+++ b/src/components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbPresentation.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 import { EuiBadge, EuiIcon } from "@elastic/eui";
 import { BreadcrumbPresentationProps } from "../../../../app/types";
@@ -5,19 +6,20 @@ import "../../../../style/ts4nfdiStyles/ts4nfdiBreadcrumbStyle.css";
 
 function BreadcrumbPresentation(props: BreadcrumbPresentationProps) {
   const finalClassName = props.className || "ts4nfdi-breadcrumb-style";
+  const clickable = !!props.onNavigateToOntology;
   return (
     <>
       <span className={finalClassName}>
         <span
           onClick={() => {
-            if (props.onNavigateToOntology)
+            if (clickable)
               props.onNavigateToOntology(
                 props.ontologyId || "",
                 undefined,
                 undefined
               );
           }}
-          role="button" // Improve accessibility
+          role={clickable ? "button" : undefined} // Improve accessibility
           tabIndex={0} // Make it focusable
           onKeyDown={(e) => {
             if (e.key === "Enter") e.currentTarget.click();
@@ -25,9 +27,7 @@ function BreadcrumbPresentation(props: BreadcrumbPresentationProps) {
         >
           <EuiBadge
             className={
-              props.ontologyId
-                ? "breadcrumb clickable-breadcrumb"
-                : "breadcrumb"
+              clickable ? "breadcrumb clickable-breadcrumb" : "breadcrumb"
             }
             color={props.colorFirst || "primary"}
           >

--- a/src/rscomponents/index.ts
+++ b/src/rscomponents/index.ts
@@ -1,0 +1,1 @@
+export * from "./widgets";

--- a/src/rscomponents/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.tsx
+++ b/src/rscomponents/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbWidget.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { OlsApi } from "../../../../api/OlsApi";
+import { BreadcrumbPresentation } from "../../../../components/widgets/MetadataWidget/BreadcrumbWidget/BreadcrumbPresentation";
+import { BreadcrumbWidgetProps } from "../../../../app";
+
+export default async function BreadcrumbWidget({
+  api,
+  useLegacy,
+  iri,
+  ontologyId,
+  entityType,
+  parameter,
+  ...props
+}: BreadcrumbWidgetProps) {
+  /**
+   * A SSR variant of the BreadcrumbWidget component using the same props API.
+   */
+  const olsApi = new OlsApi(api);
+  const entityObject = await olsApi.getEntityObject(
+    iri,
+    entityType,
+    ontologyId,
+    parameter,
+    useLegacy
+  );
+  return (
+    <BreadcrumbPresentation
+      ontologyId={entityObject.getOntologyId()}
+      ontologyName={entityObject.getOntologyId()}
+      shortForm={entityObject.getShortForm()}
+      {...props}
+    />
+  );
+}

--- a/src/rscomponents/widgets/MetadataWidget/BreadcrumbWidget/index.ts
+++ b/src/rscomponents/widgets/MetadataWidget/BreadcrumbWidget/index.ts
@@ -1,0 +1,1 @@
+export { BreadcrumbWidget } from "./BreadcrumbWidget";

--- a/src/rscomponents/widgets/MetadataWidget/index.ts
+++ b/src/rscomponents/widgets/MetadataWidget/index.ts
@@ -1,0 +1,1 @@
+export * from "./BreadcrumbWidget";

--- a/src/rscomponents/widgets/index.ts
+++ b/src/rscomponents/widgets/index.ts
@@ -1,0 +1,1 @@
+export * from "./MetadataWidget";


### PR DESCRIPTION
### Description of the change
Adds a BreadcrumbWidget component that can be rendered on the server. Also, fixes the BreadcrumbPresentation component that it can be used as a client component.
### Screenshot of before and after the change
–
### Possible drawbacks
Currently, the component has to be within a suspense boundary because the EuiIcon component used in BreadcrumbPresentation is [implemented as a class component](https://github.com/elastic/eui/blob/1d728a80a2d69d71d0fd076ba0de0d762d2944ce/packages/eui/src/components/icon/icon.tsx).
### Release notes (single line that explains this improvement in terms that a user can understand)
Add a BreadcrumbWidget component that can be rendered on the server.