### PR TITLE
Fix/autocomplete fixes

### DIFF
--- a/dist_plainjs/manually_maintained_types.d.ts
+++ b/dist_plainjs/manually_maintained_types.d.ts
@@ -23,6 +23,7 @@ declare global {
       showApiSource?: boolean;
       className?: string;
       useLegacy?: string;
+      initialSearchQuery?: string;
     }
     ) => void,
     createDataContent: (props: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ts4nfdi/terminology-service-suite",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ts4nfdi/terminology-service-suite",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "license": "MIT",
       "dependencies": {
         "@elastic/datemath": "^5.0.3",

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -206,6 +206,10 @@ export type AutocompleteWidgetProps = EuiComboBoxProps<string> &
      * Whether to show the api source in the result list or not. Default is true. Only when the API gateway is selected.
      */
     showApiSource?: boolean;
+    /**
+     * Initial search value to show results on first render.
+     */
+    initialSearchQuery?: string;
   };
 
 export type DataContentWidgetProps = ApiObj & ParameterObj;

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -520,7 +520,7 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
         async={true}
         isLoading={isLoadingTerms || isLoadingOnMount}
         singleSelection={singleSelection ? { asPlainText: true } : false}
-        placeholder={placeholder ? placeholder : "Search for a Concept"}
+        placeholder={placeholder ? placeholder : ""}
         options={options}
         selectedOptions={selectedOptions}
         onSearchChange={setSearchValue}

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -55,7 +55,7 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
   const [searchValue, setSearchValue] = useState<string>("");
 
   /**
-   * The set of available options.s
+   * The set of available options
    */
   const [options, setOptions] = useState<Array<EuiComboBoxOptionOption<any>>>(
     [],
@@ -111,11 +111,21 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
       return (
         <span className={finalClassName}>
           <EuiHealth color={dotColor}>
-            <span>
-              <EuiHighlight search={searchValue}>{value.label}</EuiHighlight>
-              <br />
+            <div style={{ display: 'flex', flexDirection: 'column', lineHeight: '1.2' }}>
+                <EuiHighlight search={searchValue}>{value.label}</EuiHighlight>
+
+                {value.description && (
+                <span style={{
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    display: "block",
+                    marginTop: "2px",
+                    color: '#666',}}>
               {value.description}
-            </span>
+          </span>
+                )}
+        </div>
           </EuiHealth>
         </span>
       );
@@ -123,37 +133,47 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
 
     const renderEntity = () => {
       return (
-        <span title={hoverText} className={finalClassName}>
-          <span>
-            <EuiHealth color={dotColor}>
-              <EuiHighlight search={searchValue}>{value.label}</EuiHighlight>
-            </EuiHealth>
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-            <BreadcrumbPresentation
-              shortForm={value.short_form}
-              colorFirst={"primary"}
-              colorSecond={"success"}
-              className={`${finalClassName}-breadcrumb`}
-            />
-            <EuiIcon
-              type={"iInCircle"}
-              style={{ marginLeft: "5px" }}
-              title={hoverText}
-            />
-          </span>
-          {!singleSuggestionRow && value.description && (
-            <span
-              style={{
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                display: "block",
-              }}
-            >
-              {value.description}
-            </span>
-          )}
+          <span title={hoverText} className={finalClassName}>
+      <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+          }}
+      >
+        <EuiHealth color={dotColor}>
+          <EuiHighlight search={searchValue}>{value.label}</EuiHighlight>
+        </EuiHealth>
+
+        <BreadcrumbPresentation
+            shortForm={value.short_form}
+            ontologyId={value.ontology_name}
+            colorFirst={"primary"}
+            colorSecond={"success"}
+            className={`${finalClassName}-breadcrumb`}
+        />
+
+        <EuiIcon
+            type={"iInCircle"}
+            title={hoverText}
+        />
+      </div>
+
+            {!singleSuggestionRow && value.description && (
+                <span
+                    style={{
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      display: "block",
+                      marginTop: "4px",
+                      color: '#666'
+                    }}
+                >
+          {value.description}
         </span>
+            )}
+    </span>
       );
     };
 

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -40,6 +40,7 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
     showApiSource = true,
     className,
     useLegacy,
+    initialSearchQuery,
     ...rest
   } = props;
 
@@ -52,7 +53,7 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
   /**
    * The current search value
    */
-  const [searchValue, setSearchValue] = useState<string>("");
+  const [searchValue, setSearchValue] = useState<string>(initialSearchQuery ?? "");
 
   /**
    * The set of available options
@@ -497,11 +498,15 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
   }, [selectedOptions]);
 
   function generateDisplayLabel(item: any): string {
+    const label = item?.getLabel();
+    if (label) return label;
+
+    const ontologyId = item?.getOntologyId()?.toUpperCase();
+    const shortForm = item?.getShortForm();
+
     return (
-      item?.getLabel() ??
-      "-" + " (" + item?.getOntologyId()?.toUpperCase() ??
-      "-" + " " + item?.getShortForm() ??
-      "-" + ")"
+        (ontologyId ? `- (${ontologyId}` : "") +
+        (shortForm ? `- (${shortForm}` : "") || "-"
     );
   }
 

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidgetHTML.stories.ts
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidgetHTML.stories.ts
@@ -52,6 +52,7 @@ window['ts4nfdiWidgets'].createAutocomplete(
         singleSuggestionRow:${args.singleSuggestionRow},
         showApiSource:${args.showApiSource},
         className: "${args.className}"
+        initialSearchQuery: "${args.initialSearchQuery}"
     },
     document.querySelector('#autocomplete_widget_container_${num}')
 )

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidgetStories.ts
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidgetStories.ts
@@ -49,6 +49,7 @@ export const AutocompleteWidgetStoryArgsReact = {
     useLegacy: true,
     parameter:
       "ontology=mesh,efo&type=class&collection=nfdi4health&fieldList=description,label,iri,ontology_name,type,short_form",
+    initialSearchQuery: "",
   },
 };
 

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidgetStories.ts
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidgetStories.ts
@@ -41,7 +41,7 @@ export const AutocompleteWidgetStoryArgsReact = {
     allowCustomTerms: false,
     selectionChangedEvent: action("selectionChangedEvent"),
     hasShortSelectedLabel: true,
-    placeholder: "Search for a Concept",
+    placeholder: "Type to search...",
     preselected: [],
     showApiSource: true,
     singleSuggestionRow: false,
@@ -62,7 +62,7 @@ export const AutocompleteWidgetStoryArgsHTML = {
       return;
     },
     hasShortSelectedLabel: true,
-    placeholder: "Search for a Concept",
+    placeholder: "Type to search...",
     preselected: [],
     showApiSource: true,
     singleSuggestionRow: false,


### PR DESCRIPTION
### fix(autocomplete): fix vertical layout shift
remove vertical layout shift between the label and the ontology breadcrumbs
closes #280

**Before:**
<img width="487" height="98" alt="grafik" src="https://github.com/user-attachments/assets/7a7a07b8-cf2a-496c-baeb-55b77d7f6e08" />

**After:**
<img width="489" height="98" alt="grafik" src="https://github.com/user-attachments/assets/c2cd4964-a744-4ae8-a8c9-277de4ce8437" />

#
### fix(autocomplete): fix empty placeholder
setting empty placeholder not working - default placeholder text ("Search for a Concept") displayed anyways
closes #278

**fixed:**
<img width="759" height="64" alt="grafik" src="https://github.com/user-attachments/assets/d0264ea6-0574-480a-9797-385d5e83a1f0" />

Additionally new default placeholder text (generalized):
<img width="237" height="54" alt="grafik" src="https://github.com/user-attachments/assets/c0b59708-b723-49b0-9e77-f60fe2d6802e" />

#
### fix(autocomplete): add initial search query prop
current message ("There aren't any options available") isn't great UX, because there actually are options available for selection as soon as you start typing
closes #279

New optional property `initialSearchQuery` (not set per default).

Set to "a" for MeSH:
<img width="753" height="256" alt="grafik" src="https://github.com/user-attachments/assets/92805336-33ae-41ca-82ed-88359ff84bb6" />
