### PR TITLE
feat(autocomplete): remove 'no options available' placeholder

### DIFF
--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -71,7 +71,7 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
 
   const finalClassName = className || "ts4nfdi-autocomplete-style";
 
-  const [displayNoSuggestions, setDisplayNoSuggestions] = useState<boolean>(true);
+  const [displaySuggestions, setDisplaySuggestions] = useState<boolean>(false);
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -452,10 +452,10 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
   );
 
   useEffect(() => {
-    if (isLoadingTerms || (preselected !== undefined && preselected?.length > 0)) {
-      setDisplayNoSuggestions(false)
+    if (isLoadingTerms || (preselected !== undefined && preselected?.length > 0) || initialSearchQuery) {
+      setDisplaySuggestions(true)
     }
-  }, [isLoadingTerms, preselected])
+  }, [isLoadingTerms, preselected, initialSearchQuery])
 
   /**
    * Once the set of selected options changes, pass the event by invoking the passed function.
@@ -561,7 +561,7 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
         renderOption={renderOption}
         onCreateOption={allowCustomTerms ? onCreateOptionHandler : undefined}
         rowHeight={singleSuggestionRow ? 30 : 50}
-        noSuggestions={displayNoSuggestions}
+        noSuggestions={!displaySuggestions}
       />
     </div>
   );

--- a/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
+++ b/src/components/widgets/AutocompleteWidget/AutocompleteWidget.tsx
@@ -71,6 +71,8 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
 
   const finalClassName = className || "ts4nfdi-autocomplete-style";
 
+  const [displayNoSuggestions, setDisplayNoSuggestions] = useState<boolean>(true);
+
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   const renderOption = (option, searchValue) => {
@@ -449,6 +451,12 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
     },
   );
 
+  useEffect(() => {
+    if (isLoadingTerms || (preselected !== undefined && preselected?.length > 0)) {
+      setDisplayNoSuggestions(false)
+    }
+  }, [isLoadingTerms, preselected])
+
   /**
    * Once the set of selected options changes, pass the event by invoking the passed function.
    */
@@ -553,6 +561,7 @@ function AutocompleteWidget(props: AutocompleteWidgetProps) {
         renderOption={renderOption}
         onCreateOption={allowCustomTerms ? onCreateOptionHandler : undefined}
         rowHeight={singleSuggestionRow ? 30 : 50}
+        noSuggestions={displayNoSuggestions}
       />
     </div>
   );


### PR DESCRIPTION
An easy solution for https://github.com/ts4nfdi/terminology-service-suite/issues/279

`noSuggestions` prop hides the suggestions list -> `noSuggestions=true` on init and `=false` if user enters data or preselected terms are available.

This is an internal autocomplete prop and can't be modified by the user.

<img width="846" height="60" alt="grafik" src="https://github.com/user-attachments/assets/9641d8b0-731e-4ed3-964b-0fb430a2c21c" />


thanks to @Freymaurer 