### PR TITLE
fix: remove old tib instance from endpoints options

### DIFF
--- a/packages/react/src/app/globals.ts
+++ b/packages/react/src/app/globals.ts
@@ -1,6 +1,5 @@
 // TIB
 export const TIB_API_ENDPOINT = "https://api.terminology.tib.eu/api/";
-export const TIB_API_ENDPOINT_OLS3 = "https://service.tib.eu/ts4tib/api/";
 
 // TS4NFDI
 export const GATEWAY_API_ENDPOINT =

--- a/packages/react/src/stories/storyArgs.ts
+++ b/packages/react/src/stories/storyArgs.ts
@@ -10,7 +10,6 @@ export const apiArgType: ArgTypes = {
     },
     options: [
       "https://terminology.services.base4nfdi.de/api-gateway/",
-      "https://service.tib.eu/ts4tib/api/",
       "https://api.terminology.tib.eu/api/",
       "https://ols3-semanticlookup.zbmed.de/ols/api/",
       "https://semanticlookup.zbmed.de/ols/api/",
@@ -21,7 +20,6 @@ export const apiArgType: ArgTypes = {
       "**[TS4NFDI:](https://base4nfdi.de/projects/ts4nfdi)**<br> " +
       "TS4NFDI API Gateway: [https://terminology.services.base4nfdi.de/api-gateway/](https://terminology.services.base4nfdi.de/api-gateway/)<br><br> " +
       "**[TIB:](https://www.tib.eu/de/)**<br> " +
-      "TIB Terminology Service (OLS3): [https://service.tib.eu/ts4tib/api/](https://service.tib.eu/ts4tib/api/)<br> " +
       "TIB Terminology Service (OLS4): [https://api.terminology.tib.eu/api/](https://api.terminology.tib.eu/api/)<br><br> " +
       "**[ZB MED:](https://www.zbmed.de/)**<br> " +
       "SemLookP API (OLS3): [https://ols3-semanticlookup.zbmed.de/ols/api/](https://ols3-semanticlookup.zbmed.de/ols/api/)<br> " +


### PR DESCRIPTION
since we are using the new tib instance, we need to remove the old one from the endpoints options