### PR TITLE
Refactor/metadata style and ontology info file path

### DIFF
--- a/packages/react/src/components/widgets/MetadataWidget/MetadataWidget.tsx
+++ b/packages/react/src/components/widgets/MetadataWidget/MetadataWidget.tsx
@@ -119,7 +119,7 @@ function MetadataWidget(props: MetadataWidgetProps) {
   function render(data: MetadataInfo) {
     return (
       <div className={finalClassName} data-testid="metadata">
-        <EuiFlexGroup direction="column">
+        <EuiFlexGroup direction="column" gutterSize={"m"}>
           <EuiFlexItem grow={false}>
             {termLink ? (
               <EuiLink href={termLink} target="_blank" external={false}>
@@ -179,28 +179,30 @@ function MetadataWidget(props: MetadataWidgetProps) {
             />
           </EuiFlexItem>
 
-          <div style={{ margin: "0 12px 0" }}>
-            <EntityOntoListPresentation
-              iri={props.iri}
-              label={data.entity.getLabel() || ""}
-              ontolist={data.ontoList}
-              entityType={
-                entityType || (data.entity.getType() as EntityTypeName)
-              }
-              onNavigateToOntology={onNavigateToOntology}
-              className={`${finalClassName}-entity-onto-list`}
-            />
-            <EntityDefinedByPresentation
-              iri={props.iri}
-              ontolist={data.definedBy}
-              label={data.entity.getLabel() || ""}
-              entityType={
-                entityType || (data.entity.getType() as EntityTypeName)
-              }
-              onNavigateToOntology={onNavigateToOntology}
-              className={`${finalClassName}-entity-defined-by`}
-            />
-          </div>
+          {(data.ontoList.length > 0 || data.definedBy.length > 0) && (
+            <div style={{ margin: "0 12px 0" }}>
+              <EntityOntoListPresentation
+                iri={props.iri}
+                label={data.entity.getLabel() || ""}
+                ontolist={data.ontoList}
+                entityType={
+                  entityType || (data.entity.getType() as EntityTypeName)
+                }
+                onNavigateToOntology={onNavigateToOntology}
+                className={`${finalClassName}-entity-onto-list`}
+              />
+              <EntityDefinedByPresentation
+                iri={props.iri}
+                ontolist={data.definedBy}
+                label={data.entity.getLabel() || ""}
+                entityType={
+                  entityType || (data.entity.getType() as EntityTypeName)
+                }
+                onNavigateToOntology={onNavigateToOntology}
+                className={`${finalClassName}-entity-defined-by`}
+              />
+            </div>
+          )}
 
           <EuiFlexItem>
             <TabWidget

--- a/packages/react/src/components/widgets/OntologyInfoWidget/OntologyInfoWidget.tsx
+++ b/packages/react/src/components/widgets/OntologyInfoWidget/OntologyInfoWidget.tsx
@@ -58,23 +58,27 @@ function OntologyInfoWidget(props: OntologyInfoWidgetProps) {
     return olsApi.getOntologyObject(ontologyId, parameter, useLegacy);
   });
 
-  function getOntologyIriSection(ontology: Ontology): ReactElement {
+  function getOntologyIriSection(
+    ontology: Ontology,
+  ): React.ReactElement | null {
+    const iri = ontology.getIri() || ontology.getOntologyPurl();
+
+    if (!iri || iri.startsWith("file:")) {
+      return null;
+    }
+
     return (
-      <>
-        {(ontology.getIri() || ontology.getOntologyPurl()) && (
-          <EuiFlexItem>
-            <b>Ontology IRI:</b>
-            <p>
-              <a
-                id={"ontologyIri"}
-                href={ontology.getIri() || ontology.getOntologyPurl()}
-              >
-                {ontology.getIri() || ontology.getOntologyPurl()}
-              </a>
-            </p>
-          </EuiFlexItem>
-        )}
-      </>
+      <EuiFlexItem>
+        <b>Ontology IRI:</b>
+        <p>
+          <a
+            id={"ontologyIri"}
+            href={ontology.getIri() || ontology.getOntologyPurl()}
+          >
+            {ontology.getIri() || ontology.getOntologyPurl()}
+          </a>
+        </p>
+      </EuiFlexItem>
     );
   }
 


### PR DESCRIPTION
Fixes https://github.com/ts4nfdi/terminology-service-suite/issues/168 and https://github.com/ts4nfdi/terminology-service-suite/issues/176

**Before:** (with file path)
<img width="556" height="378" alt="grafik" src="https://github.com/user-attachments/assets/f6508412-51a6-4460-be40-3afba2272460" />

**After:** (without file path)
<img width="557" height="316" alt="grafik" src="https://github.com/user-attachments/assets/9bc7fe9e-5d6f-4d31-8334-d7babe772051" />

**Before:** (with empty space)
<img width="314" height="361" alt="grafik" src="https://github.com/user-attachments/assets/e8f67ee5-1ec3-41fe-9a65-08493bfffb0a" />

**After:** (without empty space)
<img width="301" height="314" alt="grafik" src="https://github.com/user-attachments/assets/8771b0b1-7dd0-45c6-b798-df2ce5943e07" />
