### PR TITLE
Fix/entity list widget api type

### DIFF
--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -868,7 +868,7 @@ export type ComparisonInputProps = {
 };
 
 export type EntityListWidgetProps = {
-  api: { entityApi: OlsEntityApi; ontologyApi: OlsOntologyApi };
+  api: string;
   ontologyId: string;
   entityType: EntityTypeName;
   parameter?: string;

--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -3,8 +3,6 @@ import { Action } from "@elastic/eui/src/components/basic_table/action_types";
 import { EuiComboBoxProps } from "@elastic/eui/src/components/combo_box/combo_box";
 import { EuiLinkColor } from "@elastic/eui/src/components/link/link";
 import { EuiTextProps } from "@elastic/eui/src/components/text/text";
-import { OlsEntityApi } from "../api/ols/OlsEntityApi";
-import { OlsOntologyApi } from "../api/ols/OlsOntologyApi";
 import { Thing } from "../model/interfaces";
 import {
   BuildHierarchyProps,


### PR DESCRIPTION
##Summary

* fixing the incorrect api prop typing in EntityListWidget
* aligning the component type definition with the actual runtime usage
* improving type safety and developer experience

##Changes

1. Fixed api prop type in EntityListWidget
2. Improved type consistency

<br/>

<img width="322" height="139" alt="Screenshot 2026-05-28 at 12 16 32" src="https://github.com/user-attachments/assets/bcd717f3-2dd8-4da3-b05b-a0f3e9bf4306" />


## Related issues

https://github.com/ts4nfdi/terminology-service-suite/issues/379