### PR TITLE
Feat/add searchbar for resources widget

### DIFF
--- a/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
+++ b/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
@@ -3,12 +3,12 @@
 import {
   Comparators,
   CriteriaWithPagination,
-  EuiBasicTable,
   EuiBasicTableColumn,
   EuiButtonIcon,
   EuiCallOut,
   EuiDescriptionList,
   EuiHorizontalRule,
+  EuiInMemoryTable,
   EuiLink,
   EuiProvider,
   EuiScreenReaderOnly,
@@ -297,13 +297,6 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
       </>
     );
 
-  const sorting = {
-    sort: {
-      field: sortField,
-      direction: sortDirection,
-    },
-  };
-
   const toggleDetails = (resource: any) => {
     const itemIdToExpandedRowMapValues = { ...itemIdToExpandedRowMap };
 
@@ -399,6 +392,7 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
       },
     },
   ];
+  console.log(pageOfItems);
   // @ts-ignore
   return (
     <div className={finalClassName} data-testid="resources">
@@ -419,12 +413,12 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
           <EuiSpacer size="s" />
           <EuiHorizontalRule margin="none" style={{ height: 2 }} />
 
-          <EuiBasicTable
+          <EuiInMemoryTable
             columns={columnsWithExpandingRowToggle}
             items={pageOfItems}
             onChange={onTableChange}
             pagination={pagination}
-            sorting={sorting}
+            sorting={true}
             itemIdToExpandedRowMap={itemIdToExpandedRowMap}
             itemId={"ontologyId"}
             {...rest}
@@ -432,23 +426,23 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
         </>
       )}
       {isLoading && (
-        <EuiBasicTable
+        <EuiInMemoryTable
           columns={columnsWithExpandingRowToggle}
           items={pageOfItems}
           onChange={onTableChange}
           pagination={pagination}
-          sorting={sorting}
+          sorting={true}
           loading
           {...rest}
         />
       )}
       {isError && (
-        <EuiBasicTable
+        <EuiInMemoryTable
           columns={columns}
           items={pageOfItems}
           onChange={onTableChange}
           pagination={pagination}
-          sorting={sorting}
+          sorting={true}
           {...rest}
           /*
                           error={getErrorMessageToDisplay(error, "resources")}

--- a/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
+++ b/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import {
-  Comparators,
-  CriteriaWithPagination,
   EuiBasicTableColumn,
   EuiButtonIcon,
   EuiCallOut,
@@ -19,25 +17,17 @@ import { css, SerializedStyles } from "@emotion/react";
 import { ReactNode, useState } from "react";
 import { QueryClient, QueryClientProvider, useQuery } from "react-query";
 import { OlsOntologyApi } from "../../../api/ols/OlsOntologyApi";
-import { OlsResource, ResourcesWidgetProps } from "../../../app/types";
+import { OlsResource, ResourcesWidgetProps } from "../../../app";
 import { OBO_FOUNDRY_REPO_URL_RAW } from "../../../app/util";
 import { Ontologies } from "../../../model/interfaces";
 import { OLS4Ontology } from "../../../model/ols4-model";
 import "../../../style/ts4nfdiStyles/ts4nfdiResourcesStyle.css";
 
-const DEFAULT_INITIAL_ENTRIES_PER_PAGE = 10;
-const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
-const DEFAULT_INITIAL_SORT_FIELD = "config.preferredPrefix";
-const DEFAULT_INITIAL_SORT_DIR = "asc" as const;
 const DEFAULT_USE_LEGACY = true as const;
 
 function ResourcesWidget(props: ResourcesWidgetProps) {
   const {
     api,
-    initialEntriesPerPage = DEFAULT_INITIAL_ENTRIES_PER_PAGE,
-    pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
-    initialSortField = DEFAULT_INITIAL_SORT_FIELD,
-    initialSortDir = DEFAULT_INITIAL_SORT_DIR,
     onNavigate,
     parameter,
     useLegacy = DEFAULT_USE_LEGACY,
@@ -46,11 +36,6 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
     ...rest
   } = props;
   const olsApi = new OlsOntologyApi(api);
-
-  const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState(initialEntriesPerPage);
-  const [sortField, setSortField] = useState<string | number>(initialSortField);
-  const [sortDirection, setSortDirection] = useState(initialSortDir);
 
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<
     Record<string, ReactNode>
@@ -113,7 +98,6 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
     {
       name: "Description",
       field: "config.description",
-      // width: "30%",
       css: css`
         display: block;
         max-height: 200px;
@@ -156,7 +140,7 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
     {
       width: "2%",
       actions: [
-        ...(props.actions || []),
+        ...(actions || []),
         {
           render: (item: OlsResource) => (
             <EuiButtonIcon
@@ -174,21 +158,6 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
       ],
     },
   ];
-
-  const onTableChange = ({
-    page,
-    sort,
-  }: CriteriaWithPagination<OlsResource>) => {
-    const { index: pageIndex, size: pageSize } = page;
-    setPageIndex(pageIndex);
-    setPageSize(pageSize);
-
-    if (sort) {
-      const { field: sortField, direction: sortDirection } = sort;
-      setSortField(sortField);
-      setSortDirection(sortDirection);
-    }
-  };
 
   const {
     data: ontologiesData,
@@ -232,70 +201,6 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
       })) || []
     : ontologiesData?.properties.map((ontology) => v2toOlsResource(ontology)) ||
       [];
-
-  const findOntologies = (
-    ontologies: any[],
-    pageIndex: number,
-    pageSize: number,
-    sortField: any,
-    sortDirection: "asc" | "desc",
-  ) => {
-    let items;
-
-    if (sortField) {
-      items = ontologies
-        .slice(0)
-        .sort(
-          Comparators.property(sortField, Comparators.default(sortDirection)),
-        );
-    } else {
-      items = ontologies;
-    }
-
-    let pageOfItems;
-
-    if (!pageIndex && !pageSize) {
-      pageOfItems = items;
-    } else {
-      const startIndex = pageIndex * pageSize;
-      pageOfItems = items.slice(
-        startIndex,
-        Math.min(startIndex + pageSize, ontologies.length),
-      );
-    }
-
-    return {
-      pageOfItems,
-      totalItemCount: ontologies.length,
-    };
-  };
-
-  const { pageOfItems, totalItemCount } = findOntologies(
-    ontos,
-    pageIndex,
-    pageSize,
-    sortField,
-    sortDirection,
-  );
-
-  const pagination = {
-    pageIndex,
-    pageSize,
-    totalItemCount,
-    pageSizeOptions,
-  };
-
-  const resultsCount =
-    pageSize === 0 ? (
-      <strong>All</strong>
-    ) : (
-      <>
-        <strong>
-          {pageSize * pageIndex + 1}-{pageSize * pageIndex + pageSize}
-        </strong>{" "}
-        of {totalItemCount}
-      </>
-    );
 
   const toggleDetails = (resource: any) => {
     const itemIdToExpandedRowMapValues = { ...itemIdToExpandedRowMap };
@@ -392,8 +297,7 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
       },
     },
   ];
-  console.log(pageOfItems);
-  // @ts-ignore
+
   return (
     <div className={finalClassName} data-testid="resources">
       {isSuccess && (
@@ -408,16 +312,15 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
           </EuiCallOut>
           <EuiSpacer size="s" />
           <EuiText size="xs">
-            Showing {resultsCount} <strong>Ontologies</strong>
+            Showing <strong>{ontos.length}</strong> <strong>Ontologies</strong>
           </EuiText>
           <EuiSpacer size="s" />
           <EuiHorizontalRule margin="none" style={{ height: 2 }} />
 
           <EuiInMemoryTable
             columns={columnsWithExpandingRowToggle}
-            items={pageOfItems}
-            onChange={onTableChange}
-            pagination={pagination}
+            items={ontos}
+            pagination={true}
             sorting={true}
             itemIdToExpandedRowMap={itemIdToExpandedRowMap}
             itemId={"ontologyId"}
@@ -428,9 +331,8 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
       {isLoading && (
         <EuiInMemoryTable
           columns={columnsWithExpandingRowToggle}
-          items={pageOfItems}
-          onChange={onTableChange}
-          pagination={pagination}
+          items={ontos}
+          pagination={true}
           sorting={true}
           loading
           {...rest}
@@ -439,9 +341,8 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
       {isError && (
         <EuiInMemoryTable
           columns={columns}
-          items={pageOfItems}
-          onChange={onTableChange}
-          pagination={pagination}
+          items={ontos}
+          pagination={true}
           sorting={true}
           {...rest}
           /*

--- a/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
+++ b/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
@@ -339,7 +339,7 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
             </p>
           </EuiCallOut>
 
-          <EuiSpacer size="l" />
+          <EuiSpacer size="m" />
           <EuiText size="xs">
             Showing <strong>{filteredOntos.length}</strong>{" "}
             <strong>Ontologies</strong>

--- a/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
+++ b/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
@@ -310,7 +310,8 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
               conditions in the respective countries.
             </p>
           </EuiCallOut>
-          <EuiSpacer size="s" />
+
+          <EuiSpacer size="l" />
           <EuiText size="xs">
             Showing <strong>{ontos.length}</strong> <strong>Ontologies</strong>
           </EuiText>

--- a/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
+++ b/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
@@ -12,6 +12,7 @@ import {
   EuiScreenReaderOnly,
   EuiSpacer,
   EuiText,
+  EuiSearchBarProps,
 } from "@elastic/eui";
 import { css, SerializedStyles } from "@emotion/react";
 import { ReactNode, useState } from "react";
@@ -40,6 +41,7 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<
     Record<string, ReactNode>
   >({});
+  const [searchQuery, setSearchQuery] = useState("");
 
   const finalClassName = className || "ts4nfdi-resources-style";
 
@@ -298,6 +300,32 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
     },
   ];
 
+  const search: EuiSearchBarProps = {
+    box: {
+      incremental: true,
+      placeholder: "Search by ontology or resource name",
+    },
+    onChange: ({ queryText }) => {
+      setSearchQuery(queryText);
+    },
+  };
+
+  const filteredOntos = ontos.filter((onto)=>{
+    if(searchQuery===""){
+      return true
+    }else {
+      const searchedItem = searchQuery.trim().toLowerCase();
+
+      const searchedShortName = (onto.ontologyId || "").toLowerCase();
+      const searchedResourceName = (onto.config?.title || "").toLowerCase();
+
+      return (
+        searchedResourceName.includes(searchedItem) ||
+        searchedShortName.includes(searchedItem)
+      );
+    }
+  })
+
   return (
     <div className={finalClassName} data-testid="resources">
       {isSuccess && (
@@ -313,16 +341,18 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
 
           <EuiSpacer size="l" />
           <EuiText size="xs">
-            Showing <strong>{ontos.length}</strong> <strong>Ontologies</strong>
+            Showing <strong>{filteredOntos.length}</strong>{" "}
+            <strong>Ontologies</strong>
           </EuiText>
           <EuiSpacer size="s" />
           <EuiHorizontalRule margin="none" style={{ height: 2 }} />
 
           <EuiInMemoryTable
             columns={columnsWithExpandingRowToggle}
-            items={ontos}
+            items={filteredOntos}
             pagination={true}
             sorting={true}
+            search={search}
             itemIdToExpandedRowMap={itemIdToExpandedRowMap}
             itemId={"ontologyId"}
             {...rest}
@@ -332,9 +362,10 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
       {isLoading && (
         <EuiInMemoryTable
           columns={columnsWithExpandingRowToggle}
-          items={ontos}
+          items={filteredOntos}
           pagination={true}
           sorting={true}
+          search={search}
           loading
           {...rest}
         />
@@ -342,9 +373,10 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
       {isError && (
         <EuiInMemoryTable
           columns={columns}
-          items={ontos}
+          items={filteredOntos}
           pagination={true}
           sorting={true}
+          search={search}
           {...rest}
           /*
                           error={getErrorMessageToDisplay(error, "resources")}

--- a/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
+++ b/packages/react/src/components/widgets/ResourcesWidget/ResourcesWidget.tsx
@@ -10,9 +10,9 @@ import {
   EuiLink,
   EuiProvider,
   EuiScreenReaderOnly,
+  EuiSearchBarProps,
   EuiSpacer,
   EuiText,
-  EuiSearchBarProps,
 } from "@elastic/eui";
 import { css, SerializedStyles } from "@emotion/react";
 import { ReactNode, useState } from "react";
@@ -310,10 +310,10 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
     },
   };
 
-  const filteredOntos = ontos.filter((onto)=>{
-    if(searchQuery===""){
-      return true
-    }else {
+  const filteredOntos = ontos.filter((onto) => {
+    if (searchQuery === "") {
+      return true;
+    } else {
       const searchedItem = searchQuery.trim().toLowerCase();
 
       const searchedShortName = (onto.ontologyId || "").toLowerCase();
@@ -324,7 +324,7 @@ function ResourcesWidget(props: ResourcesWidgetProps) {
         searchedShortName.includes(searchedItem)
       );
     }
-  })
+  });
 
   return (
     <div className={finalClassName} data-testid="resources">


### PR DESCRIPTION
## Summary

The resources table now supports searching ontologies by:

- ontology short name

- resource name

The implementation has also been simplified and cleaned up.

## changes:

- Replaced `EuiBasicTable` with `EuiInMemoryTable`.
- Removed the custom manual pagination and sorting logic.
- Let `EuiInMemoryTable` handle pagination and sorting internally.
- Added an incremental search bar with the placeholder:
  `Search by ontology or resource name`
- Added filtering based on `ontologyId` and `config.title`.
- Updated the shown ontology count to reflect the filtered results.
- Simplified the component state by removing:
  - `pageIndex`
  - `pageSize`
  - `sortField`
  - `sortDirection`
  - manual `rows per page` logic
  - manual `findOntologies` logic
  - manual pagination and sorting config
- Cleaned up action usage by using the destructured `actions` prop instead of `props.actions`.

## Notes

The table behavior is now cleaner and easier to maintain because search, pagination, and sorting are handled by `EuiInMemoryTable` instead of custom table state and helper logic.


## Testing

Initially, the table shows 22 results.
<img width="1251" height="695" alt="Screenshot 2026-07-01 at 11 48 12" src="https://github.com/user-attachments/assets/2656fcf0-ed85-491d-b7e8-cfea7c656a55" />

<br/>
<br/>

When searching for `sc` in the short name column, only 1 result is shown.
<img width="1254" height="323" alt="Screenshot 2026-07-01 at 11 50 13" src="https://github.com/user-attachments/assets/5fc18a2f-9549-4bae-8b91-8dab8b1787c4" />

<br/>
<br/>

When searching for `FOO` in the resource name column, 2 results are shown.
<img width="1258" height="512" alt="Screenshot 2026-07-01 at 11 50 42" src="https://github.com/user-attachments/assets/e59885af-e0e6-443b-ba64-9cced522963b" />

<br/>
<br/>


Although the previous custom pagination, sorting functions, and rows per page were removed, the new implementation still supports pagination and sorting through `EuiInMemoryTable`. This makes the behavior smoother, simpler, and easier to maintain, while automatically staying aligned with the current search results and displayed item count.
<img width="1242" height="47" alt="Screenshot 2026-07-01 at 11 57 11" src="https://github.com/user-attachments/assets/2ce0fd34-46cf-4aea-af6c-eca22a4bbafe" />

<br/>

## Related Issue:
https://github.com/ts4nfdi/terminology-service-suite/issues/152