### PR TITLE
Feature/entity info widget formula representation

### DIFF
--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -357,9 +357,14 @@ export type MathFormulaWidgetProps = OptionalIriObj &
   ApiObj &
   OptionalOntologyIdObj & {
     /**
-     * The math property URI to render for the target term
+     * The math property URI to render for the target term.
+     * Required when mathML is not provided.
      */
     mathProperty?: string;
+    /**
+     * Inline MathML string to render directly.
+     * When provided, iri, ontologyId, and mathProperty are not required.
+     */
     mathML?: string;
   };
 

--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -353,9 +353,9 @@ export type DescriptionPresentationProps = DescTextObj &
     error?: string | unknown;
   };
 
-export type MathFormulaWidgetProps = ForcedIriObj &
+export type MathFormulaWidgetProps = OptionalIriObj &
   ApiObj &
-  ForcedOntologyIdObj & {
+  OptionalOntologyIdObj & {
     /**
      * The math property URI to render for the target term
      */

--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -359,7 +359,8 @@ export type MathFormulaWidgetProps = ForcedIriObj &
     /**
      * The math property URI to render for the target term
      */
-    mathProperty: string;
+    mathProperty?: string;
+    mathML?: string;
   };
 
 export type IriWidgetProps = ForcedIriObj &

--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -360,6 +360,7 @@ export type MathFormulaWidgetProps = ForcedIriObj &
      * The math property URI to render for the target term
      */
     mathProperty: string;
+    mathML?: string;
   };
 
 export type IriWidgetProps = ForcedIriObj &

--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -359,7 +359,7 @@ export type MathFormulaWidgetProps = ForcedIriObj &
     /**
      * The math property URI to render for the target term
      */
-    mathProperty: string;
+    mathProperty?: string;
     mathML?: string;
   };
 

--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -359,8 +359,7 @@ export type MathFormulaWidgetProps = ForcedIriObj &
     /**
      * The math property URI to render for the target term
      */
-    mathProperty?: string;
-    mathML?: string;
+    mathProperty: string;
   };
 
 export type IriWidgetProps = ForcedIriObj &

--- a/packages/react/src/app/widgetDescriptions.ts
+++ b/packages/react/src/app/widgetDescriptions.ts
@@ -218,12 +218,12 @@ Supports flexible color customization for the IRI link text, using either hex, R
 
 export const MathFormulaDescription = `
 The MathFormulaWidget renders MathML formulas for ontology entities.
-It can either fetch MathML from a configured math property or render MathML that is passed directly through the \`mathML\` prop.
+It supports two input modes: fetching MathML from an entity property, or rendering MathML that is passed directly through the \`mathML\` prop.
 
 #### Usage:
 
-- Use \`mathProperty\` when the MathML is stored as an annotation/property value on the target entity.
-- Use \`mathML\` when the MathML content is already available and should be rendered directly.
+- Use \`mathProperty\` together with \`iri\` and \`ontologyId\` when the MathML is stored as an annotation/property value on the target entity.
+- Use \`mathML\` when the MathML content is already available and should be rendered directly. In this mode, \`iri\`, \`ontologyId\`, and \`mathProperty\` are not required.
 - The \`mathML\` value must be valid MathML markup, not an entity IRI or plain text.
 - Plain text can be rendered only when it is wrapped in valid MathML, for example inside an \`mtext\` element.
 

--- a/packages/react/src/app/widgetDescriptions.ts
+++ b/packages/react/src/app/widgetDescriptions.ts
@@ -216,6 +216,19 @@ Allows for a custom URL prefix (\`urlPrefix\`) to be applied to the IRI before d
 Supports flexible color customization for the IRI link text, using either hex, RGB, or predefined color options.
 `.trim();
 
+export const MathFormulaDescription = `
+The MathFormulaWidget renders MathML formulas for ontology entities.
+It can either fetch MathML from a configured math property or render MathML that is passed directly through the \`mathML\` prop.
+
+#### Usage:
+
+- Use \`mathProperty\` when the MathML is stored as an annotation/property value on the target entity.
+- Use \`mathML\` when the MathML content is already available and should be rendered directly.
+- The \`mathML\` value must be valid MathML markup, not an entity IRI or plain text.
+- Plain text can be rendered only when it is wrapped in valid MathML, for example inside an \`mtext\` element.
+
+`.trim();
+
 export const MetadataDescription = `
 The MetadataWidget provides detailed metadata for a given entity (such as a class, property, or individual) within an ontology. 
 The widget displays the entity's title, breadcrumb, IRI, description, and lists of ontologies where the entity appears 

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -41,6 +41,15 @@ import { MathFormulaWidget } from "../MetadataWidget";
 
 const DEFAULT_HAS_TITLE = true;
 
+function isReifiedAssertion(value: any, useLegacy?: boolean): boolean {
+  return (
+    useLegacy === false &&
+    typeof value === "object" &&
+    Array.isArray(value.type) &&
+    value.type.includes("reification")
+  );
+}
+
 function EntityInfoWidget(props: EntityInfoWidgetProps) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const {
@@ -362,6 +371,17 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
     individual: Individual,
   ): ReactElement {
     const propertyIris = Object.keys(individual.properties);
+
+    // console.log(individual.properties);
+    // console.log(propertyIris); including 37 items
+    // console.log(individual.properties["https://portal.mardi4nfdi.de/entity/P983"]);
+
+    console.log(
+      individual
+        .getLinkedEntities()
+        .get("https://portal.mardi4nfdi.de/entity/P983"),
+    );
+
     const negativeProperties = propertyIris.filter((key) =>
       key.startsWith("negativePropertyAssertion+"),
     );
@@ -373,6 +393,8 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
           .get(key)
           ?.type.indexOf("objectProperty") !== -1,
     );
+    // console.log(objectProperties); // =>[]
+
     const dataProperties = propertyIris.filter(
       (key) =>
         individual.getLinkedEntities().get(key) &&
@@ -381,6 +403,8 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
           .get(key)
           ?.type.indexOf("dataProperty") !== -1,
     );
+    // console.log(dataProperties); //["https://portal.mardi4nfdi.de/entity/P983", "https://portal.mardi4nfdi.de/entity/P989"]
+
     const propertyAssertions: ReactElement[] = [];
 
     for (const iri of objectProperties) {
@@ -425,10 +449,14 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
         );
       }
     }
+    // console.log(propertyAssertions);  // =>[]
 
     for (const iri of dataProperties) {
       const values = asArray(individual.properties[iri]);
       for (const v of values) {
+        // console.log(values); //including math + types
+        // console.log(v); // math
+
         propertyAssertions.push(
           <>
             <ClassExpression
@@ -445,13 +473,17 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                   &#9656;
                 </span>
                 &nbsp;
-                <EntityLink
-                  parentEntity={individual}
-                  linkedEntities={individual.getLinkedEntities()}
-                  iri={v}
-                  showBadges={showBadges}
-                  onNavigates={onNavigates}
-                />
+                {isReifiedAssertion(v, useLegacy) ? (
+                  <>{v.value}</>
+                ) : (
+                  <EntityLink
+                    parentEntity={individual}
+                    linkedEntities={individual.getLinkedEntities()}
+                    iri={v}
+                    showBadges={showBadges}
+                    onNavigates={onNavigates}
+                  />
+                )}
               </>
             }
           </>,

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -435,6 +435,40 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
       },
     ];
 
+    function renderFormulaMeaningValue(valueIri: string): ReactElement {
+      if (valueIri === individual.getIri()) {
+        return (
+          <button
+            className="clickable"
+            onClick={() => {
+              if (typeof onNavigates.onNavigateToEntity === "function") {
+                onNavigates.onNavigateToEntity(
+                  individual.getOntologyId(),
+                  individual.getType(),
+                  {
+                    iri: valueIri,
+                    label: individual.getLabel(),
+                  },
+                );
+              }
+            }}
+          >
+            {individual.getLabel()}
+          </button>
+        );
+      }
+
+      return (
+        <EntityLink
+          parentEntity={individual}
+          linkedEntities={individual.getLinkedEntities()}
+          iri={valueIri}
+          showBadges={showBadges}
+          onNavigates={onNavigates}
+        />
+      );
+    }
+
     for (const iri of objectProperties) {
       const values = asArray(individual.properties[iri]);
       for (const v of values) {
@@ -499,14 +533,7 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                     showBadges={showBadges}
                     onNavigates={onNavigates}
                   />
-                  :{" "}
-                  <EntityLink
-                    parentEntity={individual}
-                    linkedEntities={individual.getLinkedEntities()}
-                    iri={axiom[axiomIri]}
-                    showBadges={showBadges}
-                    onNavigates={onNavigates}
-                  />
+                  : {renderFormulaMeaningValue(axiom[axiomIri])}
                 </span>,
               );
             });

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -471,9 +471,9 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                   <>
                     {renderMathML(v.value)}
                     {asArray(v.axioms).map((axiom) => (
-                      <div key={randomString()}>
+                      <ul style={{ listStyleType: "circle" }}>
                         {Object.keys(axiom).map((axiomIri) => (
-                          <div key={randomString()}>
+                          <li key={randomString()}>
                             <ClassExpression
                               parentEntity={individual}
                               linkedEntities={individual.getLinkedEntities()}
@@ -490,9 +490,9 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                               onNavigates={onNavigates}
                             />
                             {/*https://portal.mardi4nfdi.de/entity/P984 :  https://portal.mardi4nfdi.de/entity/Q6673756*/}
-                          </div>
+                          </li>
                         ))}
-                      </div>
+                      </ul>
                     ))}
                   </>
                 ) : typeof v === "string" && v.trim().startsWith("<math") ? (

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -481,7 +481,13 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                   <>
                     {renderMathML(v.value)}
                     {asArray(v.axioms).map((axiom) => (
-                      <div key={randomString()}>{JSON.stringify(axiom)}</div>
+                      <div key={randomString()}>
+                        {Object.keys(axiom).map((axiomIri) => (
+                          <div key={randomString()}>
+                            {axiomIri}: {axiom[axiomIri]}
+                          </div>
+                        ))}
+                      </div>
                     ))}
                   </>
                 ) : typeof v === "string" && v.trim().startsWith("<math") ? (

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -41,6 +41,10 @@ import { MathFormulaWidget } from "../MetadataWidget";
 
 const DEFAULT_HAS_TITLE = true;
 
+function renderMathML(mathML: string): ReactElement {
+  return <span dangerouslySetInnerHTML={{ __html: mathML }} />;
+}
+
 function isReifiedAssertion(value: any, useLegacy?: boolean): boolean {
   return (
     useLegacy === false &&
@@ -474,7 +478,7 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                 </span>
                 &nbsp;
                 {isReifiedAssertion(v, useLegacy) ? (
-                  <>{v.value}</>
+                  <>{renderMathML(v.value)}</>
                 ) : (
                   <EntityLink
                     parentEntity={individual}

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -478,7 +478,12 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                 </span>
                 &nbsp;
                 {isReifiedAssertion(v, useLegacy) ? (
-                  renderMathML(v.value)
+                  <>
+                    {renderMathML(v.value)}
+                    {asArray(v.axioms).map((axiom) => (
+                      <div key={randomString()}>{JSON.stringify(axiom)}</div>
+                    ))}
+                  </>
                 ) : typeof v === "string" && v.trim().startsWith("<math") ? (
                   renderMathML(v)
                 ) : (
@@ -494,8 +499,9 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
             }
           </>,
         );
-        console.log("iri", iri);
-        console.log("v", v);
+        // console.log("iri", iri);
+        // console.log("v", v);
+        console.log("axioms", v.axioms);
       }
     }
 

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -41,10 +41,6 @@ import { MathFormulaWidget } from "../MetadataWidget";
 
 const DEFAULT_HAS_TITLE = true;
 
-function renderMathML(mathML: string): ReactElement {
-  return <span dangerouslySetInnerHTML={{ __html: mathML }} />;
-}
-
 function isReifiedAssertion(value: any, useLegacy?: boolean): boolean {
   return (
     useLegacy === false &&
@@ -469,7 +465,6 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                 &nbsp;
                 {isReifiedAssertion(v, useLegacy) ? (
                   <>
-                    {renderMathML(v.value)}
                     {asArray(v.axioms).map((axiom) => (
                       <ul style={{ listStyleType: "circle" }}>
                         {Object.keys(axiom).map((axiomIri) => (
@@ -495,8 +490,6 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                       </ul>
                     ))}
                   </>
-                ) : typeof v === "string" && v.trim().startsWith("<math") ? (
-                  renderMathML(v)
                 ) : (
                   <EntityLink
                     parentEntity={individual}

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -469,12 +469,7 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                 &nbsp;
                 {isReifiedAssertion(v, useLegacy) ? (
                   <>
-                    <MathFormulaWidget
-                      api={api}
-                      iri={iri}
-                      ontologyId={entity?.getOntologyId() ?? ""}
-                      mathML={v.value}
-                    />
+                    {renderMathML(v.value)}
                     {asArray(v.axioms).map((axiom) => (
                       <div key={randomString()}>
                         {Object.keys(axiom).map((axiomIri) => (
@@ -501,12 +496,7 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                     ))}
                   </>
                 ) : typeof v === "string" && v.trim().startsWith("<math") ? (
-                  <MathFormulaWidget
-                    api={api}
-                    iri={iri}
-                    ontologyId={entity?.getOntologyId() ?? ""}
-                    mathML={v}
-                  />
+                  renderMathML(v)
                 ) : (
                   <EntityLink
                     parentEntity={individual}

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -376,10 +376,6 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
   ): ReactElement {
     const propertyIris = Object.keys(individual.properties);
 
-    // console.log(individual.properties);
-    // console.log(propertyIris); including 37 items
-    // console.log(individual.properties["https://portal.mardi4nfdi.de/entity/P983"]);
-
     console.log(
       individual
         .getLinkedEntities()
@@ -397,7 +393,6 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
           .get(key)
           ?.type.indexOf("objectProperty") !== -1,
     );
-    // console.log(objectProperties); // =>[]
 
     const dataProperties = propertyIris.filter(
       (key) =>
@@ -407,7 +402,6 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
           .get(key)
           ?.type.indexOf("dataProperty") !== -1,
     );
-    // console.log(dataProperties); //["https://portal.mardi4nfdi.de/entity/P983", "https://portal.mardi4nfdi.de/entity/P989"]
 
     const propertyAssertions: ReactElement[] = [];
 
@@ -453,14 +447,10 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
         );
       }
     }
-    // console.log(propertyAssertions);  // =>[]
 
     for (const iri of dataProperties) {
       const values = asArray(individual.properties[iri]);
       for (const v of values) {
-        // console.log(values); //including math + types
-        // console.log(v); // math
-
         propertyAssertions.push(
           <>
             <ClassExpression
@@ -520,9 +510,6 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
             }
           </>,
         );
-        // console.log("iri", iri);
-        // console.log("v", v);
-        console.log("axioms", v.axioms);
       }
     }
 

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -484,7 +484,22 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                       <div key={randomString()}>
                         {Object.keys(axiom).map((axiomIri) => (
                           <div key={randomString()}>
-                            {axiomIri}: {axiom[axiomIri]}
+                            <ClassExpression
+                              parentEntity={individual}
+                              linkedEntities={individual.getLinkedEntities()}
+                              currentResponsePath={axiomIri}
+                              showBadges={showBadges}
+                              onNavigates={onNavigates}
+                            />
+                            :{" "}
+                            <EntityLink
+                              parentEntity={individual}
+                              linkedEntities={individual.getLinkedEntities()}
+                              iri={axiom[axiomIri]}
+                              showBadges={showBadges}
+                              onNavigates={onNavigates}
+                            />
+                            {/*https://portal.mardi4nfdi.de/entity/P984 :  https://portal.mardi4nfdi.de/entity/Q6673756*/}
                           </div>
                         ))}
                       </div>

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -465,6 +465,14 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                 &nbsp;
                 {isReifiedAssertion(v, useLegacy) ? (
                   <>
+                    {typeof v.value === "string" && isMathML(v.value) && (
+                      <MathFormulaWidget
+                        iri={iri}
+                        api={api}
+                        ontologyId={individual.getOntologyId()}
+                        mathML={v.value}
+                      />
+                    )}
                     {asArray(v.axioms).map((axiom) => (
                       <ul style={{ listStyleType: "circle" }}>
                         {Object.keys(axiom).map((axiomIri) => (
@@ -490,6 +498,13 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                       </ul>
                     ))}
                   </>
+                ) : typeof v === "string" && isMathML(v) ? (
+                  <MathFormulaWidget
+                    iri={iri}
+                    api={api}
+                    ontologyId={individual.getOntologyId()}
+                    mathML={v}
+                  />
                 ) : (
                   <EntityLink
                     parentEntity={individual}

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import type { EuiBasicTableColumn } from "@elastic/eui";
 import {
+  EuiBasicTable,
   EuiCard,
   EuiFlexItem,
   EuiLoadingSpinner,
@@ -40,6 +42,12 @@ import Tooltip from "../../helperComponents/Tooltip";
 import { MathFormulaWidget } from "../MetadataWidget";
 
 const DEFAULT_HAS_TITLE = true;
+
+type FormulaSymbolRow = {
+  symbol: ReactElement;
+  meanings: ReactElement[];
+  sortValue: string;
+};
 
 function isReifiedAssertion(value: any, useLegacy?: boolean): boolean {
   return (
@@ -372,11 +380,11 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
   ): ReactElement {
     const propertyIris = Object.keys(individual.properties);
 
-    console.log(
-      individual
-        .getLinkedEntities()
-        .get("https://portal.mardi4nfdi.de/entity/P983"),
-    );
+    // console.log(
+    //   individual
+    //     .getLinkedEntities()
+    //     .get("https://portal.mardi4nfdi.de/entity/P983"),
+    // );
 
     const negativeProperties = propertyIris.filter((key) =>
       key.startsWith("negativePropertyAssertion+"),
@@ -400,6 +408,32 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
     );
 
     const propertyAssertions: ReactElement[] = [];
+    const formulaAssertions: ReactElement[] = [];
+    const formulaSymbolRows: {
+      symbol: ReactElement;
+      meanings: ReactElement[];
+      sortValue: string;
+    }[] = [];
+    const formulaSymbolColumns: Array<EuiBasicTableColumn<FormulaSymbolRow>> = [
+      {
+        field: "symbol",
+        name: "Symbol",
+        width: "120px",
+        render: (symbol: ReactElement) => symbol,
+      },
+      {
+        field: "meanings",
+        name: "Meaning",
+        width: "520px",
+        render: (meanings: ReactElement[]) => (
+          <>
+            {meanings.map((meaning) => (
+              <div key={randomString()}>{meaning}</div>
+            ))}
+          </>
+        ),
+      },
+    ];
 
     for (const iri of objectProperties) {
       const values = asArray(individual.properties[iri]);
@@ -447,6 +481,65 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
     for (const iri of dataProperties) {
       const values = asArray(individual.properties[iri]);
       for (const v of values) {
+        if (
+          isReifiedAssertion(v, useLegacy) &&
+          typeof v.value === "string" &&
+          isMathML(v.value)
+        ) {
+          const meanings: ReactElement[] = [];
+
+          asArray(v.axioms).forEach((axiom) => {
+            Object.keys(axiom).forEach((axiomIri) => {
+              meanings.push(
+                <span key={randomString()}>
+                  <ClassExpression
+                    parentEntity={individual}
+                    linkedEntities={individual.getLinkedEntities()}
+                    currentResponsePath={axiomIri}
+                    showBadges={showBadges}
+                    onNavigates={onNavigates}
+                  />
+                  :{" "}
+                  <EntityLink
+                    parentEntity={individual}
+                    linkedEntities={individual.getLinkedEntities()}
+                    iri={axiom[axiomIri]}
+                    showBadges={showBadges}
+                    onNavigates={onNavigates}
+                  />
+                </span>,
+              );
+            });
+          });
+
+          formulaSymbolRows.push({
+            symbol: (
+              <MathFormulaWidget
+                iri={iri}
+                api={api}
+                ontologyId={individual.getOntologyId()}
+                mathML={v.value}
+              />
+            ),
+            meanings,
+            sortValue: v.value,
+          });
+          continue;
+        }
+
+        if (typeof v === "string" && isMathML(v)) {
+          formulaAssertions.push(
+            <MathFormulaWidget
+              key={randomString()}
+              iri={iri}
+              api={api}
+              ontologyId={individual.getOntologyId()}
+              mathML={v}
+            />,
+          );
+          continue;
+        }
+
         propertyAssertions.push(
           <>
             <ClassExpression
@@ -465,14 +558,6 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                 &nbsp;
                 {isReifiedAssertion(v, useLegacy) ? (
                   <>
-                    {typeof v.value === "string" && isMathML(v.value) && (
-                      <MathFormulaWidget
-                        iri={iri}
-                        api={api}
-                        ontologyId={individual.getOntologyId()}
-                        mathML={v.value}
-                      />
-                    )}
                     {asArray(v.axioms).map((axiom) => (
                       <ul style={{ listStyleType: "circle" }}>
                         {Object.keys(axiom).map((axiomIri) => (
@@ -498,13 +583,6 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                       </ul>
                     ))}
                   </>
-                ) : typeof v === "string" && isMathML(v) ? (
-                  <MathFormulaWidget
-                    iri={iri}
-                    api={api}
-                    ontologyId={individual.getOntologyId()}
-                    mathML={v}
-                  />
                 ) : (
                   <EntityLink
                     parentEntity={individual}
@@ -590,10 +668,37 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
 
     return (
       <>
-        {propertyAssertions.length > 0 && (
+        {(formulaAssertions.length > 0 ||
+          formulaSymbolRows.length > 0 ||
+          propertyAssertions.length > 0) && (
           <>
             <EuiFlexItem>
               <b>Property assertions:</b>
+              {formulaAssertions.length > 0 && (
+                <div style={{ marginTop: "12px", marginBottom: "16px" }}>
+                  <b>Formula:</b>
+                  {formulaAssertions}
+                </div>
+              )}
+              {formulaSymbolRows.length > 0 && (
+                <div
+                  style={{
+                    marginTop: "12px",
+                    marginBottom: "20px",
+                    maxWidth: "720px",
+                  }}
+                >
+                  <EuiBasicTable<FormulaSymbolRow>
+                    tableCaption="Formula symbols"
+                    responsiveBreakpoint={false}
+                    tableLayout="auto"
+                    items={[...formulaSymbolRows].sort((a, b) =>
+                      a.sortValue.localeCompare(b.sortValue),
+                    )}
+                    columns={formulaSymbolColumns}
+                  />
+                </div>
+              )}
               {propertyAssertions.length > 1 ? (
                 <>
                   <ul>
@@ -612,8 +717,10 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                   </ul>
                   <p></p>
                 </>
-              ) : (
+              ) : propertyAssertions.length === 1 ? (
                 <p>{propertyAssertions[0]}</p>
+              ) : (
+                <></>
               )}
             </EuiFlexItem>
           </>

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -607,7 +607,7 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                         return (
                           <li
                             key={randomString()}
-                            style={{ marginBottom: "16px" }}
+                            style={{ marginBottom: "24px" }}
                           >
                             {pa}
                           </li>

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -478,7 +478,9 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                 </span>
                 &nbsp;
                 {isReifiedAssertion(v, useLegacy) ? (
-                  <>{renderMathML(v.value)}</>
+                  renderMathML(v.value)
+                ) : typeof v === "string" && v.trim().startsWith("<math") ? (
+                  renderMathML(v)
                 ) : (
                   <EntityLink
                     parentEntity={individual}
@@ -492,6 +494,8 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
             }
           </>,
         );
+        console.log("iri", iri);
+        console.log("v", v);
       }
     }
 
@@ -573,7 +577,14 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                   <ul>
                     {propertyAssertions
                       .map((pa) => {
-                        return <li key={randomString()}>{pa}</li>;
+                        return (
+                          <li
+                            key={randomString()}
+                            style={{ marginBottom: "16px" }}
+                          >
+                            {pa}
+                          </li>
+                        );
                       })
                       .sort()}
                   </ul>

--- a/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
+++ b/packages/react/src/components/widgets/EntityInfoWidget/EntityInfoWidget.tsx
@@ -469,7 +469,12 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                 &nbsp;
                 {isReifiedAssertion(v, useLegacy) ? (
                   <>
-                    {renderMathML(v.value)}
+                    <MathFormulaWidget
+                      api={api}
+                      iri={iri}
+                      ontologyId={entity?.getOntologyId() ?? ""}
+                      mathML={v.value}
+                    />
                     {asArray(v.axioms).map((axiom) => (
                       <div key={randomString()}>
                         {Object.keys(axiom).map((axiomIri) => (
@@ -496,7 +501,12 @@ function EntityInfoWidget(props: EntityInfoWidgetProps) {
                     ))}
                   </>
                 ) : typeof v === "string" && v.trim().startsWith("<math") ? (
-                  renderMathML(v)
+                  <MathFormulaWidget
+                    api={api}
+                    iri={iri}
+                    ontologyId={entity?.getOntologyId() ?? ""}
+                    mathML={v}
+                  />
                 ) : (
                   <EntityLink
                     parentEntity={individual}

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.stories.tsx
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.stories.tsx
@@ -1,9 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MathFormulaDescription } from "../../../../app/widgetDescriptions";
 import { MathFormulaWidget } from "./MathFormulaWidget";
 import {
   commonMathFormulaWidgetPlay,
   MathFormulaWidgetStoryArgs,
   MathFormulaWidgetStoryArgTypes,
+  MathMLFractionInputStoryArgs,
+  MathMLInputStoryArgs,
+  MathMLTextInputStoryArgs,
   MathmodP983StoryArgs,
   MathmodP989StoryArgs,
 } from "./MathFormulaWidgetStories";
@@ -13,6 +17,11 @@ const meta = {
   component: MathFormulaWidget,
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component: MathFormulaDescription,
+      },
+    },
   },
   argTypes: MathFormulaWidgetStoryArgTypes,
   args: MathFormulaWidgetStoryArgs,
@@ -29,5 +38,44 @@ export const MathmodP983: Story = {
 
 export const MathmodP989: Story = {
   args: MathmodP989StoryArgs,
+  play: commonMathFormulaWidgetPlay,
+};
+
+export const MathMLInput: Story = {
+  args: MathMLInputStoryArgs,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders a simple formula from a direct MathML string. The value of mathML should be MathML markup, not an entity IRI.",
+      },
+    },
+  },
+  play: commonMathFormulaWidgetPlay,
+};
+
+export const MathMLTextInput: Story = {
+  args: MathMLTextInputStoryArgs,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows how plain text can be rendered when it is wrapped in valid MathML, for example inside an mtext element.",
+      },
+    },
+  },
+  play: commonMathFormulaWidgetPlay,
+};
+
+export const MathMLFractionInput: Story = {
+  args: MathMLFractionInputStoryArgs,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders a slightly more complex MathML formula with a fraction.",
+      },
+    },
+  },
   play: commonMathFormulaWidgetPlay,
 };

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.tsx
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.tsx
@@ -54,6 +54,8 @@ function MathFormulaWidget(props: MathFormulaWidgetProps) {
   const { data, isLoading, isSuccess, isLoadingError, error } = useQuery(
     ["mathFormula", iri, ontologyId, mathProperty],
     async () => {
+      if (!iri || !ontologyId) return undefined;
+
       return olsApi.getEntityObject(
         iri,
         "class",
@@ -63,7 +65,11 @@ function MathFormulaWidget(props: MathFormulaWidgetProps) {
       );
     },
     {
-      enabled: !hasInlineMathML && Boolean(mathProperty),
+      enabled:
+        !hasInlineMathML &&
+        Boolean(mathProperty) &&
+        Boolean(iri) &&
+        Boolean(ontologyId),
     },
   );
 

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.tsx
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.tsx
@@ -4,8 +4,7 @@ import { MathJax, MathJaxContext } from "better-react-mathjax";
 import DOMPurify from "dompurify";
 import { QueryClient, QueryClientProvider, useQuery } from "react-query";
 import { OlsEntityApi } from "../../../../api/ols/OlsEntityApi";
-import { MathFormulaWidgetProps } from "../../../../app/types";
-import { Thing } from "../../../../model/interfaces";
+import { MathFormulaWidgetProps } from "../../../../app";
 
 const ALLOWED_TAGS = [
   "math",
@@ -47,11 +46,13 @@ const ALLOWED_ATTR = [
 ];
 
 function MathFormulaWidget(props: MathFormulaWidgetProps) {
-  const { api, ontologyId, iri, mathProperty } = props;
+  const { api, ontologyId, iri, mathProperty, mathML } = props;
+
+  const hasInlineMathML = typeof mathML === "string" && mathML.trim() !== "";
 
   const olsApi = new OlsEntityApi(api);
-  const { data, isLoading, isSuccess, isLoadingError, error } = useQuery<Thing>(
-    ["mathFormulaWidget", api, iri, ontologyId],
+  const { data, isLoading, isSuccess, isLoadingError, error } = useQuery(
+    ["mathFormula", iri, ontologyId, mathProperty],
     async () => {
       return olsApi.getEntityObject(
         iri,
@@ -60,6 +61,9 @@ function MathFormulaWidget(props: MathFormulaWidgetProps) {
         "",
         false,
       );
+    },
+    {
+      enabled: !hasInlineMathML && Boolean(mathProperty),
     },
   );
 
@@ -81,8 +85,8 @@ function MathFormulaWidget(props: MathFormulaWidgetProps) {
     });
   }
 
-  let mathContent = "";
-  if (data && isSuccess) {
+  let mathContent = hasInlineMathML ? mathML.trim() : "";
+  if (data && isSuccess && !hasInlineMathML && mathProperty) {
     let mathValue = data.getAnnotationById(mathProperty);
     if (mathValue && mathValue.length && "value" in mathValue[0]) {
       mathContent = mathValue[0].value;
@@ -123,6 +127,7 @@ function WrappedMathFormulaWidget(props: MathFormulaWidgetProps) {
           iri={props.iri}
           mathProperty={props.mathProperty}
           api={props.api}
+          mathML={props.mathML}
         />
       </QueryClientProvider>
     </EuiProvider>

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.tsx
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.tsx
@@ -47,7 +47,7 @@ const ALLOWED_ATTR = [
 ];
 
 function MathFormulaWidget(props: MathFormulaWidgetProps) {
-  const { api, ontologyId, iri, mathProperty } = props;
+  const { api, ontologyId, iri, mathProperty, mathML } = props;
 
   const olsApi = new OlsEntityApi(api);
   const { data, isLoading, isSuccess, isLoadingError, error } = useQuery<Thing>(
@@ -81,8 +81,8 @@ function MathFormulaWidget(props: MathFormulaWidgetProps) {
     });
   }
 
-  let mathContent = "";
-  if (data && isSuccess) {
+  let mathContent = props.mathML ?? "";
+  if (!props.mathML && data && isSuccess) {
     let mathValue = data.getAnnotationById(mathProperty);
     if (mathValue && mathValue.length && "value" in mathValue[0]) {
       mathContent = mathValue[0].value;

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.tsx
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.tsx
@@ -47,7 +47,7 @@ const ALLOWED_ATTR = [
 ];
 
 function MathFormulaWidget(props: MathFormulaWidgetProps) {
-  const { api, ontologyId, iri, mathProperty, mathML } = props;
+  const { api, ontologyId, iri, mathProperty } = props;
 
   const olsApi = new OlsEntityApi(api);
   const { data, isLoading, isSuccess, isLoadingError, error } = useQuery<Thing>(
@@ -81,8 +81,8 @@ function MathFormulaWidget(props: MathFormulaWidgetProps) {
     });
   }
 
-  let mathContent = props.mathML ?? "";
-  if (!props.mathML && data && isSuccess) {
+  let mathContent = "";
+  if (data && isSuccess) {
     let mathValue = data.getAnnotationById(mathProperty);
     if (mathValue && mathValue.length && "value" in mathValue[0]) {
       mathContent = mathValue[0].value;

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
@@ -2,6 +2,7 @@ import { expect, waitFor, within } from "storybook/test";
 import {
   apiArgType,
   iriArgType,
+  mathMLArgType,
   mathPorpertyArgType,
   ontologyIdArgType,
 } from "../../../../stories/storyArgs";
@@ -24,15 +25,7 @@ export const MathFormulaWidgetStoryArgTypes = {
   ...iriArgType,
   ...ontologyIdArgType,
   ...mathPorpertyArgType,
-  mathML: {
-    control: { type: "text" } as const,
-    description:
-      "Inline MathML string to render directly. This should be MathML markup, not an entity IRI. When provided, mathProperty is not required.",
-    table: {
-      type: { summary: "string" },
-      defaultValue: { summary: SimpleMathMLExample },
-    },
-  },
+  ...mathMLArgType,
 };
 
 export const MathMLInputStoryArgs = {

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
@@ -6,11 +6,54 @@ import {
   ontologyIdArgType,
 } from "../../../../stories/storyArgs";
 
+const mathmodApi = "https://ols4-mathmod.qa.km.k8s.zbmed.de/ols/api/";
+const mathmodOntologyId = "mathmod";
+const mathmodEntityIri = "https://portal.mardi4nfdi.de/entity/Q6674137";
+
+export const SimpleMathMLExample =
+  '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi><mo>=</mo><mn>1</mn></math>';
+
+export const TextMathMLExample =
+  '<math xmlns="http://www.w3.org/1998/Math/MathML"><mtext>formula example</mtext></math>';
+
+export const FractionMathMLExample =
+  '<math xmlns="http://www.w3.org/1998/Math/MathML"><mfrac><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow><mi>c</mi></mfrac></math>';
+
 export const MathFormulaWidgetStoryArgTypes = {
   ...apiArgType,
   ...iriArgType,
   ...ontologyIdArgType,
   ...mathPorpertyArgType,
+  mathML: {
+    control: { type: "text" } as const,
+    description:
+      "Inline MathML string to render directly. This should be MathML markup, not an entity IRI. When provided, mathProperty is not required.",
+    table: {
+      type: { summary: "string" },
+      defaultValue: { summary: SimpleMathMLExample },
+    },
+  },
+};
+
+export const MathMLInputStoryArgs = {
+  api: mathmodApi,
+  ontologyId: mathmodOntologyId,
+  iri: mathmodEntityIri,
+  mathML: SimpleMathMLExample,
+};
+
+export const MathMLTextInputStoryArgs = {
+  api: mathmodApi,
+  ontologyId: mathmodOntologyId,
+  iri: mathmodEntityIri,
+  mathML: TextMathMLExample,
+};
+
+export const MathMLFractionInputStoryArgs = {
+  api: mathmodApi,
+  ontologyId: mathmodOntologyId,
+  iri: mathmodEntityIri,
+  mathML: FractionMathMLExample,
 };
 
 export const MathFormulaWidgetStoryArgs = {
@@ -20,16 +63,16 @@ export const MathFormulaWidgetStoryArgs = {
 } as const;
 
 export const MathmodP983StoryArgs = {
-  api: "https://ols4-mathmod.qa.km.k8s.zbmed.de/ols/api/",
-  ontologyId: "mathmod",
-  iri: "https://portal.mardi4nfdi.de/entity/Q6674137",
+  api: mathmodApi,
+  ontologyId: mathmodOntologyId,
+  iri: mathmodEntityIri,
   mathProperty: "https://portal.mardi4nfdi.de/entity/P983",
 };
 
 export const MathmodP989StoryArgs = {
-  api: "https://ols4-mathmod.qa.km.k8s.zbmed.de/ols/api/",
-  ontologyId: "mathmod",
-  iri: "https://portal.mardi4nfdi.de/entity/Q6674137",
+  api: mathmodApi,
+  ontologyId: mathmodOntologyId,
+  iri: mathmodEntityIri,
   mathProperty: "https://portal.mardi4nfdi.de/entity/P989",
 };
 

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
@@ -1,10 +1,11 @@
+import type { ArgTypes } from "@storybook/react";
 import { expect, waitFor, within } from "storybook/test";
 import {
   apiArgType,
-  iriArgType,
+  mathFormulaIriArgType,
+  mathFormulaOntologyIdArgType,
   mathMLArgType,
   mathPorpertyArgType,
-  ontologyIdArgType,
 } from "../../../../stories/storyArgs";
 
 const mathmodApi = "https://ols4-mathmod.qa.km.k8s.zbmed.de/ols/api/";
@@ -20,10 +21,10 @@ export const TextMathMLExample =
 export const FractionMathMLExample =
   '<math xmlns="http://www.w3.org/1998/Math/MathML"><mfrac><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow><mi>c</mi></mfrac></math>';
 
-export const MathFormulaWidgetStoryArgTypes = {
+export const MathFormulaWidgetStoryArgTypes: ArgTypes = {
   ...apiArgType,
-  ...iriArgType,
-  ...ontologyIdArgType,
+  ...mathFormulaIriArgType,
+  ...mathFormulaOntologyIdArgType,
   ...mathPorpertyArgType,
   ...mathMLArgType,
 };

--- a/packages/react/src/stories/storyArgs.ts
+++ b/packages/react/src/stories/storyArgs.ts
@@ -105,6 +105,25 @@ export const ontologyIdArgTypeHierarchy = {
     `,
   },
 };
+
+export const mathFormulaIriArgType: ArgTypes = {
+  iri: {
+    ...iriArgType.iri,
+    required: false,
+    description:
+      "Entity IRI whose information you want to fetch. Required when mathML is not provided.",
+  },
+};
+
+export const mathFormulaOntologyIdArgType = {
+  ontologyId: {
+    ...ontologyIdArgType.ontologyId,
+    required: false,
+    description:
+      "Select a specific ontology by ID. Required when mathML is not provided.",
+  },
+};
+
 export const entityTypeArgType = {
   entityType: {
     required: false,
@@ -1071,9 +1090,10 @@ export const hideLegendArgType = {
 };
 
 export const mathPorpertyArgType = {
-  iri: {
-    required: true,
-    description: "The target property URI that holds the MathMl content",
+  mathProperty: {
+    required: false,
+    description:
+      "The math property URI to render for the target term. Required when mathML is not provided.",
     table: {
       type: { summary: "string" },
     },

--- a/packages/react/src/stories/storyArgs.ts
+++ b/packages/react/src/stories/storyArgs.ts
@@ -1079,3 +1079,17 @@ export const mathPorpertyArgType = {
     },
   },
 };
+
+export const mathMLArgType = {
+  mathML: {
+    required: false,
+    control: { type: "text" } as const,
+    description:
+      "Inline MathML string to render directly. This should be MathML markup, not an entity IRI. " +
+      "When provided, mathProperty is not required.<br><br>" +
+      'Example: `<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi><mo>=</mo><mn>1</mn></math>`',
+    table: {
+      type: { summary: "string" },
+    },
+  },
+};


### PR DESCRIPTION
## Summary

This PR improves formula rendering in `EntityInfoWidget` for the non-legacy API response.

### What changed

- Added support for reified formula property assertions.
- Rendered MathML values via `MathFormulaWidget` instead of showing raw MathML text.
- Handled both:
  - reified formula parts, where the formula is stored in `value`
  - inline MathML strings, where the full formula is stored directly as the property value
- Resolved formula symbol descriptions from `axioms`.
- Displayed formula symbols and meanings in a compact `EuiBasicTable`.
- Kept resolved axiom labels and target entities clickable, including references to the current entity itself.

### Result

Users can now see readable formula parts and their meanings, such as:

- `t` -> `symbol represents: time`
- `x` -> `symbol represents: opinion`

The full formula also continues to render correctly.

<img width="499" height="507" alt="Screenshot 2026-07-17 at 16 53 04" src="https://github.com/user-attachments/assets/2543f647-a2f2-4c06-ab80-0e0f6d845a83" />

</br>

<img width="500" height="432" alt="Screenshot 2026-07-17 at 16 52 17" src="https://github.com/user-attachments/assets/4ff43cbf-d148-4aed-bf6b-03f040764202" />

</br>

<img width="503" height="440" alt="Screenshot 2026-07-17 at 16 51 27" src="https://github.com/user-attachments/assets/2e301717-cafb-4ef8-9d33-c5d96937824e" />

</br>

### Scope

This behavior is only applied for `useLegacy=false`.


### Related issue

https://github.com/ts4nfdi/terminology-service-suite/issues/393