### PR TITLE
Math formula widget mathml story

### DIFF
--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -357,9 +357,14 @@ export type MathFormulaWidgetProps = OptionalIriObj &
   ApiObj &
   OptionalOntologyIdObj & {
     /**
-     * The math property URI to render for the target term
+     * The math property URI to render for the target term.
+     * Required when mathML is not provided.
      */
     mathProperty?: string;
+    /**
+     * Inline MathML string to render directly.
+     * When provided, iri, ontologyId, and mathProperty are not required.
+     */
     mathML?: string;
   };
 

--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -353,9 +353,9 @@ export type DescriptionPresentationProps = DescTextObj &
     error?: string | unknown;
   };
 
-export type MathFormulaWidgetProps = ForcedIriObj &
+export type MathFormulaWidgetProps = OptionalIriObj &
   ApiObj &
-  ForcedOntologyIdObj & {
+  OptionalOntologyIdObj & {
     /**
      * The math property URI to render for the target term
      */

--- a/packages/react/src/app/widgetDescriptions.ts
+++ b/packages/react/src/app/widgetDescriptions.ts
@@ -218,12 +218,12 @@ Supports flexible color customization for the IRI link text, using either hex, R
 
 export const MathFormulaDescription = `
 The MathFormulaWidget renders MathML formulas for ontology entities.
-It can either fetch MathML from a configured math property or render MathML that is passed directly through the \`mathML\` prop.
+It supports two input modes: fetching MathML from an entity property, or rendering MathML that is passed directly through the \`mathML\` prop.
 
 #### Usage:
 
-- Use \`mathProperty\` when the MathML is stored as an annotation/property value on the target entity.
-- Use \`mathML\` when the MathML content is already available and should be rendered directly.
+- Use \`mathProperty\` together with \`iri\` and \`ontologyId\` when the MathML is stored as an annotation/property value on the target entity.
+- Use \`mathML\` when the MathML content is already available and should be rendered directly. In this mode, \`iri\`, \`ontologyId\`, and \`mathProperty\` are not required.
 - The \`mathML\` value must be valid MathML markup, not an entity IRI or plain text.
 - Plain text can be rendered only when it is wrapped in valid MathML, for example inside an \`mtext\` element.
 

--- a/packages/react/src/app/widgetDescriptions.ts
+++ b/packages/react/src/app/widgetDescriptions.ts
@@ -216,6 +216,19 @@ Allows for a custom URL prefix (\`urlPrefix\`) to be applied to the IRI before d
 Supports flexible color customization for the IRI link text, using either hex, RGB, or predefined color options.
 `.trim();
 
+export const MathFormulaDescription = `
+The MathFormulaWidget renders MathML formulas for ontology entities.
+It can either fetch MathML from a configured math property or render MathML that is passed directly through the \`mathML\` prop.
+
+#### Usage:
+
+- Use \`mathProperty\` when the MathML is stored as an annotation/property value on the target entity.
+- Use \`mathML\` when the MathML content is already available and should be rendered directly.
+- The \`mathML\` value must be valid MathML markup, not an entity IRI or plain text.
+- Plain text can be rendered only when it is wrapped in valid MathML, for example inside an \`mtext\` element.
+
+`.trim();
+
 export const MetadataDescription = `
 The MetadataWidget provides detailed metadata for a given entity (such as a class, property, or individual) within an ontology. 
 The widget displays the entity's title, breadcrumb, IRI, description, and lists of ontologies where the entity appears 

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.stories.tsx
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.stories.tsx
@@ -1,9 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MathFormulaDescription } from "../../../../app/widgetDescriptions";
 import { MathFormulaWidget } from "./MathFormulaWidget";
 import {
   commonMathFormulaWidgetPlay,
   MathFormulaWidgetStoryArgs,
   MathFormulaWidgetStoryArgTypes,
+  MathMLFractionInputStoryArgs,
+  MathMLInputStoryArgs,
+  MathMLTextInputStoryArgs,
   MathmodP983StoryArgs,
   MathmodP989StoryArgs,
 } from "./MathFormulaWidgetStories";
@@ -13,6 +17,11 @@ const meta = {
   component: MathFormulaWidget,
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component: MathFormulaDescription,
+      },
+    },
   },
   argTypes: MathFormulaWidgetStoryArgTypes,
   args: MathFormulaWidgetStoryArgs,
@@ -29,5 +38,44 @@ export const MathmodP983: Story = {
 
 export const MathmodP989: Story = {
   args: MathmodP989StoryArgs,
+  play: commonMathFormulaWidgetPlay,
+};
+
+export const MathMLInput: Story = {
+  args: MathMLInputStoryArgs,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders a simple formula from a direct MathML string. The value of mathML should be MathML markup, not an entity IRI.",
+      },
+    },
+  },
+  play: commonMathFormulaWidgetPlay,
+};
+
+export const MathMLTextInput: Story = {
+  args: MathMLTextInputStoryArgs,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows how plain text can be rendered when it is wrapped in valid MathML, for example inside an mtext element.",
+      },
+    },
+  },
+  play: commonMathFormulaWidgetPlay,
+};
+
+export const MathMLFractionInput: Story = {
+  args: MathMLFractionInputStoryArgs,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders a slightly more complex MathML formula with a fraction.",
+      },
+    },
+  },
   play: commonMathFormulaWidgetPlay,
 };

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.tsx
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.tsx
@@ -54,6 +54,8 @@ function MathFormulaWidget(props: MathFormulaWidgetProps) {
   const { data, isLoading, isSuccess, isLoadingError, error } = useQuery(
     ["mathFormula", iri, ontologyId, mathProperty],
     async () => {
+      if (!iri || !ontologyId) return undefined;
+
       return olsApi.getEntityObject(
         iri,
         "class",
@@ -63,7 +65,11 @@ function MathFormulaWidget(props: MathFormulaWidgetProps) {
       );
     },
     {
-      enabled: !hasInlineMathML && Boolean(mathProperty),
+      enabled:
+        !hasInlineMathML &&
+        Boolean(mathProperty) &&
+        Boolean(iri) &&
+        Boolean(ontologyId),
     },
   );
 

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
@@ -2,6 +2,7 @@ import { expect, waitFor, within } from "storybook/test";
 import {
   apiArgType,
   iriArgType,
+  mathMLArgType,
   mathPorpertyArgType,
   ontologyIdArgType,
 } from "../../../../stories/storyArgs";
@@ -24,15 +25,7 @@ export const MathFormulaWidgetStoryArgTypes = {
   ...iriArgType,
   ...ontologyIdArgType,
   ...mathPorpertyArgType,
-  mathML: {
-    control: { type: "text" } as const,
-    description:
-      "Inline MathML string to render directly. This should be MathML markup, not an entity IRI. When provided, mathProperty is not required.",
-    table: {
-      type: { summary: "string" },
-      defaultValue: { summary: SimpleMathMLExample },
-    },
-  },
+  ...mathMLArgType,
 };
 
 export const MathMLInputStoryArgs = {

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
@@ -6,11 +6,54 @@ import {
   ontologyIdArgType,
 } from "../../../../stories/storyArgs";
 
+const mathmodApi = "https://ols4-mathmod.qa.km.k8s.zbmed.de/ols/api/";
+const mathmodOntologyId = "mathmod";
+const mathmodEntityIri = "https://portal.mardi4nfdi.de/entity/Q6674137";
+
+export const SimpleMathMLExample =
+  '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi><mo>=</mo><mn>1</mn></math>';
+
+export const TextMathMLExample =
+  '<math xmlns="http://www.w3.org/1998/Math/MathML"><mtext>formula example</mtext></math>';
+
+export const FractionMathMLExample =
+  '<math xmlns="http://www.w3.org/1998/Math/MathML"><mfrac><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow><mi>c</mi></mfrac></math>';
+
 export const MathFormulaWidgetStoryArgTypes = {
   ...apiArgType,
   ...iriArgType,
   ...ontologyIdArgType,
   ...mathPorpertyArgType,
+  mathML: {
+    control: { type: "text" } as const,
+    description:
+      "Inline MathML string to render directly. This should be MathML markup, not an entity IRI. When provided, mathProperty is not required.",
+    table: {
+      type: { summary: "string" },
+      defaultValue: { summary: SimpleMathMLExample },
+    },
+  },
+};
+
+export const MathMLInputStoryArgs = {
+  api: mathmodApi,
+  ontologyId: mathmodOntologyId,
+  iri: mathmodEntityIri,
+  mathML: SimpleMathMLExample,
+};
+
+export const MathMLTextInputStoryArgs = {
+  api: mathmodApi,
+  ontologyId: mathmodOntologyId,
+  iri: mathmodEntityIri,
+  mathML: TextMathMLExample,
+};
+
+export const MathMLFractionInputStoryArgs = {
+  api: mathmodApi,
+  ontologyId: mathmodOntologyId,
+  iri: mathmodEntityIri,
+  mathML: FractionMathMLExample,
 };
 
 export const MathFormulaWidgetStoryArgs = {
@@ -20,16 +63,16 @@ export const MathFormulaWidgetStoryArgs = {
 } as const;
 
 export const MathmodP983StoryArgs = {
-  api: "https://ols4-mathmod.qa.km.k8s.zbmed.de/ols/api/",
-  ontologyId: "mathmod",
-  iri: "https://portal.mardi4nfdi.de/entity/Q6674137",
+  api: mathmodApi,
+  ontologyId: mathmodOntologyId,
+  iri: mathmodEntityIri,
   mathProperty: "https://portal.mardi4nfdi.de/entity/P983",
 };
 
 export const MathmodP989StoryArgs = {
-  api: "https://ols4-mathmod.qa.km.k8s.zbmed.de/ols/api/",
-  ontologyId: "mathmod",
-  iri: "https://portal.mardi4nfdi.de/entity/Q6674137",
+  api: mathmodApi,
+  ontologyId: mathmodOntologyId,
+  iri: mathmodEntityIri,
   mathProperty: "https://portal.mardi4nfdi.de/entity/P989",
 };
 

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
@@ -1,10 +1,11 @@
+import type { ArgTypes } from "@storybook/react";
 import { expect, waitFor, within } from "storybook/test";
 import {
   apiArgType,
-  iriArgType,
+  mathFormulaIriArgType,
+  mathFormulaOntologyIdArgType,
   mathMLArgType,
   mathPorpertyArgType,
-  ontologyIdArgType,
 } from "../../../../stories/storyArgs";
 
 const mathmodApi = "https://ols4-mathmod.qa.km.k8s.zbmed.de/ols/api/";
@@ -20,10 +21,10 @@ export const TextMathMLExample =
 export const FractionMathMLExample =
   '<math xmlns="http://www.w3.org/1998/Math/MathML"><mfrac><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow><mi>c</mi></mfrac></math>';
 
-export const MathFormulaWidgetStoryArgTypes = {
+export const MathFormulaWidgetStoryArgTypes: ArgTypes = {
   ...apiArgType,
-  ...iriArgType,
-  ...ontologyIdArgType,
+  ...mathFormulaIriArgType,
+  ...mathFormulaOntologyIdArgType,
   ...mathPorpertyArgType,
   ...mathMLArgType,
 };

--- a/packages/react/src/stories/storyArgs.ts
+++ b/packages/react/src/stories/storyArgs.ts
@@ -105,6 +105,25 @@ export const ontologyIdArgTypeHierarchy = {
     `,
   },
 };
+
+export const mathFormulaIriArgType: ArgTypes = {
+  iri: {
+    ...iriArgType.iri,
+    required: false,
+    description:
+      "Entity IRI whose information you want to fetch. Required when mathML is not provided.",
+  },
+};
+
+export const mathFormulaOntologyIdArgType = {
+  ontologyId: {
+    ...ontologyIdArgType.ontologyId,
+    required: false,
+    description:
+      "Select a specific ontology by ID. Required when mathML is not provided.",
+  },
+};
+
 export const entityTypeArgType = {
   entityType: {
     required: false,
@@ -1071,9 +1090,10 @@ export const hideLegendArgType = {
 };
 
 export const mathPorpertyArgType = {
-  iri: {
-    required: true,
-    description: "The target property URI that holds the MathMl content",
+  mathProperty: {
+    required: false,
+    description:
+      "The math property URI to render for the target term. Required when mathML is not provided.",
     table: {
       type: { summary: "string" },
     },

--- a/packages/react/src/stories/storyArgs.ts
+++ b/packages/react/src/stories/storyArgs.ts
@@ -1079,3 +1079,17 @@ export const mathPorpertyArgType = {
     },
   },
 };
+
+export const mathMLArgType = {
+  mathML: {
+    required: false,
+    control: { type: "text" } as const,
+    description:
+      "Inline MathML string to render directly. This should be MathML markup, not an entity IRI. " +
+      "When provided, mathProperty is not required.<br><br>" +
+      'Example: `<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi><mo>=</mo><mn>1</mn></math>`',
+    table: {
+      type: { summary: "string" },
+    },
+  },
+};


### PR DESCRIPTION
## Summary

This PR improves the Storybook documentation and examples for `MathFormulaWidget`.

## What Changed

- Added MathML input examples for `MathFormulaWidget` in Storybook.
- Added separate stories showing different valid `mathML` inputs:
  - a simple formula
  - plain text wrapped in valid MathML
  - a fraction formula
- Added documentation for the `mathML` argument.
- Clarified that `mathML` must be valid MathML markup, not an entity IRI or plain text.
- Clarified that `iri`, `ontologyId`, and `mathProperty` are only required when `mathML` is not provided.
- Updated `MathFormulaWidgetProps` so `iri` and `ontologyId` are optional for direct `mathML` input.
- Prevented the widget from calling the API unless `mathProperty`, `iri`, and `ontologyId` are available.

## Result

Users can now understand how to use `MathFormulaWidget` in both supported modes:

- Fetch MathML from an entity property using `iri`, `ontologyId`, and `mathProperty`.
- Render MathML directly by passing a valid `mathML` string.

<img width="1259" height="610" alt="Screenshot 2026-07-22 at 13 44 18" src="https://github.com/user-attachments/assets/1b062b51-a74a-4c90-8977-5016c8c570ec" />

</br>
</br>

<img width="1258" height="739" alt="Screenshot 2026-07-22 at 13 45 09" src="https://github.com/user-attachments/assets/bd4c9b21-959f-4c7e-9a9d-f610e1eee451" />
