### PR TITLE
fix: route refs through proxy

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -37,11 +37,11 @@ module.exports = {
     return {
       react: {
         title: "REACT",
-        url: "https://ts4nfdi.github.io/terminology-service-suite/react/latest",
+        url: "https://terminology.services.base4nfdi.de/tss/react/latest",
       },
       html: {
         title: "Plain JavaScript",
-        url: "https://ts4nfdi.github.io/terminology-service-suite/html/latest",
+        url: "https://terminology.services.base4nfdi.de/tss/html/latest",
       },
     };
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for your interest in contributing! Your contributions help improve the
 
 Here are some quick links to essential project resources:
 
-- **Documentation:** [Latest](https://ts4nfdi.github.io/terminology-service-suite/comp/latest/) | [All Versions](https://ts4nfdi.github.io/terminology-service-suite/)
+- **Documentation:** [Latest](https://terminology.services.base4nfdi.de/tss/comp/latest/) | [All Versions](https://terminology.services.base4nfdi.de/tss/)
 - **Development instructions:** [Wiki](https://github.com/ts4nfdi/terminology-service-suite/wiki/Development-instructions)
 
 ## Reporting Bugs

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.7.0",
   "description": "This project includes a widget component library derived from the semantic lookup service SemLookP. The Terminology Service is a repository for biomedical resources that aims to provide a single point of access to the latest ontology and terminology versions. User interface (UI) functionalities were extracted and implemented as separate widgets to allow integration into other 3rd party services, thus simplifying the development of user interfaces and the visualization of semantic information. The widgets are built with React and TypeScript and can be used in React applications. SemLookP and the widgets are based on the Ontology Lookup Service (OLS), software developed by EBI.",
   "repository": "https://github.com/ts4nfdi/terminology-service-suite.git",
-  "homepage": "https://ts4nfdi.github.io/terminology-service-suite/comp/latest/?path=/docs/overview--docs",
+  "homepage": "https://terminology.services.base4nfdi.de/tss/comp/latest/?path=/docs/overview--docs",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts4nfdi/terminology-service-suite",
-  "version": "5.7.0",
+  "version": "7.0.0",
   "description": "This project includes a widget component library derived from the semantic lookup service SemLookP. The Terminology Service is a repository for biomedical resources that aims to provide a single point of access to the latest ontology and terminology versions. User interface (UI) functionalities were extracted and implemented as separate widgets to allow integration into other 3rd party services, thus simplifying the development of user interfaces and the visualization of semantic information. The widgets are built with React and TypeScript and can be used in React applications. SemLookP and the widgets are based on the Ontology Lookup Service (OLS), software developed by EBI.",
   "repository": "https://github.com/ts4nfdi/terminology-service-suite.git",
   "homepage": "https://terminology.services.base4nfdi.de/tss/comp/latest/?path=/docs/overview--docs",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -13,7 +13,7 @@
   "module": "./dist/index.es.js",
   "types": "./dist/js/src/index.d.ts",
   "repository": "https://github.com/ts4nfdi/terminology-service-suite.git",
-  "homepage": "https://ts4nfdi.github.io/terminology-service-suite/comp/latest/?path=/docs/overview--docs",
+  "homepage": "https://terminology.services.base4nfdi.de/tss/comp/latest/?path=/docs/overview--docs",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,7 +13,7 @@
     "package.json"
   ],
   "repository": "https://github.com/ts4nfdi/terminology-service-suite.git",
-  "homepage": "https://ts4nfdi.github.io/terminology-service-suite/comp/latest/?path=/docs/overview--docs",
+  "homepage": "https://terminology.services.base4nfdi.de/tss/comp/latest/?path=/docs/overview--docs",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"


### PR DESCRIPTION
instead of hitting GitHub Pages directly, which results in a same-origin issue. Also changed some refs of the GitHub Storybook.

closes #398