### PR TITLE
fix(EntityDefinedByWidget): add useLegacy to the stories

### DIFF
--- a/packages/react/src/components/widgets/MetadataWidget/EntityDefinedByWidget/EntityDefinedByWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/EntityDefinedByWidget/EntityDefinedByWidgetStories.ts
@@ -35,12 +35,14 @@ export const emptyInDefiningOntologyArgs = {
   api: globals.EBI_API_ENDPOINT,
   entityType: "term",
   ontologyId: "efo",
+  useLegacy: true,
 } as const;
 
 export const v2ApiFOODONArgs = {
   iri: "http://purl.obolibrary.org/obo/NCBITaxon_10090",
   api: globals.ZBMED_OLS4_API,
   ontologyId: "foodon",
+  useLegacy: true,
 } as const;
 
 export const legacyApiArgs = {

--- a/packages/react/src/components/widgets/MetadataWidget/EntityDefinedByWidget/EntityDefinedByWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/EntityDefinedByWidget/EntityDefinedByWidgetStories.ts
@@ -42,7 +42,7 @@ export const v2ApiFOODONArgs = {
   iri: "http://purl.obolibrary.org/obo/NCBITaxon_10090",
   api: globals.ZBMED_OLS4_API,
   ontologyId: "foodon",
-  useLegacy: true,
+  useLegacy: false,
 } as const;
 
 export const legacyApiArgs = {


### PR DESCRIPTION

## Problem

During testing, we found that:

- `EntityDefinedByWidget` did not display any content by default
- the widget started working only when the `useLegacy` parameter was added

This suggests the default rendering path was not being applied correctly.


## Testing

Verified across multiple demo stories that:

- the widget now renders by default
- behavior with `useLegacy` remains consistent

<img width="534" height="705" alt="def" src="https://github.com/user-attachments/assets/7f76accc-da98-49b2-a620-90e56fbce048" />


## fixed issue
(https://github.com/ts4nfdi/terminology-service-suite/issues/391)