### PR TITLE
fix(EntityOntoListWidget): add useLegacy to the stories

### DIFF
--- a/packages/react/src/components/widgets/MetadataWidget/EntityOntoListWidget/EntityOntoListWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/EntityOntoListWidget/EntityOntoListWidgetStories.ts
@@ -35,7 +35,7 @@ export const v2ApiNCBITaxonArgs = {
   api: globals.ZBMED_OLS4_API,
   entityType: "term",
   ontologyId: "ncbitaxon",
-  useLegacy: true,
+  useLegacy: false,
 } as const;
 
 export const v2ApiFOODONArgs = {

--- a/packages/react/src/components/widgets/MetadataWidget/EntityOntoListWidget/EntityOntoListWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/EntityOntoListWidget/EntityOntoListWidgetStories.ts
@@ -42,7 +42,7 @@ export const v2ApiFOODONArgs = {
   iri: "http://purl.obolibrary.org/obo/NCBITaxon_10090",
   api: globals.ZBMED_OLS4_API,
   ontologyId: "foodon",
-  useLegacy: true,
+  useLegacy: false,
 } as const;
 
 export const legacyApiArgs = {

--- a/packages/react/src/components/widgets/MetadataWidget/EntityOntoListWidget/EntityOntoListWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/EntityOntoListWidget/EntityOntoListWidgetStories.ts
@@ -35,12 +35,14 @@ export const v2ApiNCBITaxonArgs = {
   api: globals.ZBMED_OLS4_API,
   entityType: "term",
   ontologyId: "ncbitaxon",
+  useLegacy: true,
 } as const;
 
 export const v2ApiFOODONArgs = {
   iri: "http://purl.obolibrary.org/obo/NCBITaxon_10090",
   api: globals.ZBMED_OLS4_API,
   ontologyId: "foodon",
+  useLegacy: true,
 } as const;
 
 export const legacyApiArgs = {
@@ -55,6 +57,7 @@ export const exceedsMaxDisplayArgs = {
   iri: "http://purl.obolibrary.org/obo/HP_0000819",
   api: globals.EBI_API_ENDPOINT,
   ontologyId: "hp",
+  useLegacy: true,
 } as const;
 
 export const commonEntityOntoListWidgetPlay = async ({


### PR DESCRIPTION

## Problem

During testing, we found that:
• `EntityOntoListWidget` did not display any content by default
• the widget started working only when the `useLegacy` parameter was added

## Testing

Verified across multiple demo stories that:
• the widget now renders by default
• behavior with `useLegacy` remains consistent

<img width="545" height="712" alt="Screenshot 2026-08-17 at 15 53 27" src="https://github.com/user-attachments/assets/2ae177cf-7f94-4557-91c1-551d397f6224" />


## fixed Issue
https://github.com/ts4nfdi/terminology-service-suite/issues/392
