### PR TITLE
fix(MathFormulaWidget): delete MathmoddbInDefiningFormulaStoryArgs an…

### DIFF
--- a/packages/js/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.stories.tsx
+++ b/packages/js/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.stories.tsx
@@ -5,9 +5,9 @@ import {
 } from "@ts4nfdi/terminology-service-suite/src";
 import {
   commonMathFormulaWidgetPlay,
+  MathFormulaWidgetStoryArgs,
   MathFormulaWidgetStoryArgTypes,
   MathmoddbDefiningFormulaStoryArgs,
-  MathmoddbInDefiningFormulaStoryArgs,
 } from "@ts4nfdi/terminology-service-suite/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories";
 import "./index";
 
@@ -45,7 +45,7 @@ window['ts4nfdiWidgets'].createMathFormula(
         `;
   },
   argTypes: MathFormulaWidgetStoryArgTypes,
-  args: MathmoddbInDefiningFormulaStoryArgs,
+  args: MathFormulaWidgetStoryArgs,
 } satisfies Meta<typeof MathFormulaWidget>;
 
 export default meta;
@@ -54,10 +54,5 @@ type Story = StoryObj<typeof meta>;
 
 export const MathmoddbDefiningFormula: Story = {
   args: MathmoddbDefiningFormulaStoryArgs,
-  play: commonMathFormulaWidgetPlay,
-};
-
-export const MathmoddbInDefiningFormula: Story = {
-  args: MathmoddbInDefiningFormulaStoryArgs,
   play: commonMathFormulaWidgetPlay,
 };

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.stories.tsx
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidget.stories.tsx
@@ -9,7 +9,6 @@ import {
   MathMLInputStoryArgs,
   MathMLTextInputStoryArgs,
   MathmoddbDefiningFormulaStoryArgs,
-  MathmoddbInDefiningFormulaStoryArgs,
 } from "./MathFormulaWidgetStories";
 
 const meta = {
@@ -33,11 +32,6 @@ type Story = StoryObj<typeof meta>;
 
 export const MathmoddbDefiningFormula: Story = {
   args: MathmoddbDefiningFormulaStoryArgs,
-  play: commonMathFormulaWidgetPlay,
-};
-
-export const MathmoddbInDefiningFormula: Story = {
-  args: MathmoddbInDefiningFormulaStoryArgs,
   play: commonMathFormulaWidgetPlay,
 };
 

--- a/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
+++ b/packages/react/src/components/widgets/MetadataWidget/MathFormulaWidget/MathFormulaWidgetStories.ts
@@ -48,13 +48,6 @@ export const MathFormulaWidgetStoryArgs = {
   iri: "",
 } as const;
 
-export const MathmoddbInDefiningFormulaStoryArgs = {
-  api: mathmodApi,
-  ontologyId: mathmodOntologyId,
-  iri: mathmodEntityIri,
-  mathProperty: "https://portal.mardi4nfdi.de/entity/P983",
-};
-
 export const MathmoddbDefiningFormulaStoryArgs = {
   api: mathmodApi,
   ontologyId: mathmodOntologyId,


### PR DESCRIPTION
## Summary

This PR removes the `Mathmoddb In Defining Formula` Storybook example from `MathFormulaWidget`.

## Changes

- Removed the `MathmoddbInDefiningFormula` story from `MathFormulaWidget.stories.tsx` both in js and react files
- Removed the unused story args from `MathFormulaWidgetStories.ts`

## fixed issue
https://github.com/ts4nfdi/terminology-service-suite/issues/404