### PR TITLE
feat(SearchResultsListWidget): result callback

### DIFF
--- a/packages/js/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.stories.tsx
+++ b/packages/js/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.stories.tsx
@@ -7,6 +7,7 @@ import { SearchResultsListDescription } from "@ts4nfdi/terminology-service-suite
 import {
   commonSearchResultsListWidgetPlay,
   DefaultArgs,
+  NavigateToSearchResultArgs,
   NFDI4HealthArgs,
   OpenEnergyPlatformArgs,
   SearchResultsListWidgetStoryArgs,
@@ -51,6 +52,7 @@ window['ts4nfdiWidgets'].createSearchResultsList(
         targetLink:"${args.targetLink}",
         useLegacy:"${args.useLegacy}",
         onNavigateToOntology:${args.onNavigateToOntology},
+        OnNavigateToSearchResult:${args.OnNavigateToSearchResult},
         className:"${args.className}"
     },
     document.querySelector('#search_results_list_widget_container_${num}')
@@ -68,6 +70,11 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: DefaultArgs,
+  play: commonSearchResultsListWidgetPlay,
+};
+
+export const NavigateToSearchResult: Story = {
+  args: NavigateToSearchResultArgs,
   play: commonSearchResultsListWidgetPlay,
 };
 

--- a/packages/react/src/app/types.ts
+++ b/packages/react/src/app/types.ts
@@ -543,6 +543,13 @@ export type OnNavigateToOntology = {
     | string;
 };
 
+export type OnNavigateToSearchResult = {
+  /**
+   * This function is called when a search result title is clicked.
+   */
+  OnNavigateToSearchResult?: ((result: SearchResultProps) => void) | string;
+};
+
 export type OnNavigateToDisambiguate = {
   /**
    * This function is called every time a disambiguation badge is clicked
@@ -555,7 +562,8 @@ export type OnNavigateToDisambiguate = {
    * @param entity.parents obtains the list of parent entities of the clicked entity (only OLS, Skosmos)
    */
   onNavigateToDisambiguate?:
-    ((entityType: string, entity?: EntityData) => void) | string;
+    | ((entityType: string, entity?: EntityData) => void)
+    | string;
 };
 
 export type OnNavigates = OnNavigateToEntity &
@@ -754,6 +762,7 @@ export type SearchResultsListWidgetProps = Partial<
   ParameterObj &
   UseLegacyObj &
   OnNavigateToOntology &
+  OnNavigateToSearchResult &
   CssClassNameObj & {
     /**
      * The terms to search. By default, the search is performed over term labels, synonyms, descriptions, identifiers and annotation properties.
@@ -795,6 +804,7 @@ export type MetadataCompactProps = Partial<Omit<EuiCardProps, "layout">> &
   CssClassNameObj &
   OptionalEntityTypeObj &
   OnNavigateToOntology & {
+    OnNavigateToSearchResult?: ((result: SearchResultProps) => void) | string;
     result: SearchResultProps;
     iri: string;
     ontologyId: string;

--- a/packages/react/src/components/widgets/SearchResultsListWidget/MetadataCompact.tsx
+++ b/packages/react/src/components/widgets/SearchResultsListWidget/MetadataCompact.tsx
@@ -1,4 +1,4 @@
-import { EuiCard, EuiLink, EuiSpacer, EuiTitle } from "@elastic/eui";
+import { EuiCard, EuiSpacer, EuiTitle } from "@elastic/eui";
 import { useQuery } from "react-query";
 import { OlsEntityApi } from "../../../api/ols/OlsEntityApi";
 import { MetadataCompactProps } from "../../../app";
@@ -105,6 +105,15 @@ function MetadataCompact(props: MetadataCompactProps) {
     <div className={className}>
       <EuiCard
         textAlign="left"
+        onClick={
+          typeof OnNavigateToSearchResult === "function"
+            ? (event: React.MouseEvent<HTMLAnchorElement>) => {
+                event.preventDefault();
+                event.stopPropagation();
+                OnNavigateToSearchResult(result);
+              }
+            : undefined
+        }
         {...rest}
         href={
           targetLink
@@ -124,21 +133,7 @@ function MetadataCompact(props: MetadataCompactProps) {
           <div>
             <EuiSpacer size="m" />
             <EuiTitle>
-              <h2>
-                {typeof OnNavigateToSearchResult === "function" ? (
-                  <EuiLink
-                    onClick={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      OnNavigateToSearchResult(result);
-                    }}
-                  >
-                    {result.label}
-                  </EuiLink>
-                ) : (
-                  result.label
-                )}
-              </h2>
+              <h2>{result.label}</h2>
             </EuiTitle>
           </div>
         }

--- a/packages/react/src/components/widgets/SearchResultsListWidget/MetadataCompact.tsx
+++ b/packages/react/src/components/widgets/SearchResultsListWidget/MetadataCompact.tsx
@@ -1,4 +1,4 @@
-import { EuiCard, EuiSpacer, EuiTitle } from "@elastic/eui";
+import { EuiCard, EuiLink, EuiSpacer, EuiTitle } from "@elastic/eui";
 import { useQuery } from "react-query";
 import { OlsEntityApi } from "../../../api/ols/OlsEntityApi";
 import { MetadataCompactProps } from "../../../app";
@@ -35,6 +35,7 @@ function MetadataCompact(props: MetadataCompactProps) {
     ontologyId,
     useLegacy,
     onNavigateToOntology,
+    OnNavigateToSearchResult,
     ...rest
   } = props;
   const olsApi = new OlsEntityApi(api);
@@ -123,7 +124,21 @@ function MetadataCompact(props: MetadataCompactProps) {
           <div>
             <EuiSpacer size="m" />
             <EuiTitle>
-              <h2>{result.label}</h2>
+              <h2>
+                {typeof OnNavigateToSearchResult === "function" ? (
+                  <EuiLink
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      OnNavigateToSearchResult(result);
+                    }}
+                  >
+                    {result.label}
+                  </EuiLink>
+                ) : (
+                  result.label
+                )}
+              </h2>
             </EuiTitle>
           </div>
         }

--- a/packages/react/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.stories.tsx
+++ b/packages/react/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.stories.tsx
@@ -4,6 +4,7 @@ import { SearchResultsListWidget } from "./SearchResultsListWidget";
 import {
   commonSearchResultsListWidgetPlay,
   DefaultArgs,
+  NavigateToSearchResultArgs,
   NFDI4HealthArgs,
   OpenEnergyPlatformArgs,
   SearchResultsListWidgetStoryArgs,
@@ -32,6 +33,11 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: DefaultArgs,
+  play: commonSearchResultsListWidgetPlay,
+};
+
+export const NavigateToSearchResult: Story = {
+  args: NavigateToSearchResultArgs,
   play: commonSearchResultsListWidgetPlay,
 };
 

--- a/packages/react/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.tsx
+++ b/packages/react/src/components/widgets/SearchResultsListWidget/SearchResultsListWidget.tsx
@@ -38,6 +38,7 @@ function SearchResultsListWidget(props: SearchResultsListWidgetProps) {
     targetLink,
     preselected,
     onNavigateToOntology,
+    OnNavigateToSearchResult,
     useLegacy = true,
     className,
     ...rest
@@ -481,6 +482,7 @@ function SearchResultsListWidget(props: SearchResultsListWidgetProps) {
                       ontologyId={result.ontology_name}
                       useLegacy={useLegacy}
                       onNavigateToOntology={onNavigateToOntology}
+                      OnNavigateToSearchResult={OnNavigateToSearchResult}
                     />
                     <EuiSpacer />
                   </React.Fragment>
@@ -505,6 +507,7 @@ function WrappedSearchResultsListWidget(props: SearchResultsListWidgetProps) {
           initialItemsPerPage={props.initialItemsPerPage}
           itemsPerPageOptions={props.itemsPerPageOptions}
           targetLink={props.targetLink}
+          OnNavigateToSearchResult={props.OnNavigateToSearchResult}
         />
       </QueryClientProvider>
     </EuiProvider>

--- a/packages/react/src/components/widgets/SearchResultsListWidget/SearchResultsListWidgetStories.ts
+++ b/packages/react/src/components/widgets/SearchResultsListWidget/SearchResultsListWidgetStories.ts
@@ -6,6 +6,7 @@ import {
   initialItemsPerPageArgType,
   itemsPerPageOptionsArgType,
   onNavigateToOntologyArgType,
+  OnNavigateToSearchResultArgType,
   parameterArgType,
   preselectedArgType,
   queryArgType,
@@ -23,6 +24,7 @@ export const SearchResultsListWidgetStoryArgTypes = {
   ...useLegacyArgType,
   ...parameterArgType,
   ...onNavigateToOntologyArgType,
+  ...OnNavigateToSearchResultArgType,
 };
 
 export const SearchResultsListWidgetStoryArgs = {
@@ -35,6 +37,7 @@ export const SearchResultsListWidgetStoryArgs = {
   targetLink: "",
   parameter: "",
   onNavigateToOntology: "Console message",
+  OnNavigateToSearchResult: "None",
 };
 
 export const DefaultArgs = {
@@ -43,6 +46,11 @@ export const DefaultArgs = {
   targetLink: "",
   parameter: "fieldList=description,label,iri,ontology_name,type,short_form",
   useLegacy: false,
+};
+
+export const NavigateToSearchResultArgs = {
+  ...DefaultArgs,
+  OnNavigateToSearchResult: "Console message",
 };
 
 export const NFDI4HealthArgs = {

--- a/packages/react/src/stories/storyArgs.ts
+++ b/packages/react/src/stories/storyArgs.ts
@@ -685,6 +685,21 @@ export const onNavigateToEntityArgType: ArgTypes = {
     },
   },
 };
+export const OnNavigateToSearchResultArgType: ArgTypes = {
+  OnNavigateToSearchResult: {
+    required: false,
+    table: { type: { summary: "(result: SearchResultProps) => void" } },
+    action: "OnNavigateToSearchResult",
+    description:
+      "This function is called when a search result title is clicked.",
+    control: { type: "radio" },
+    options: ["None", "Console message"],
+    mapping: {
+      None: undefined,
+      "Console message": (result: unknown) => console.log(result),
+    },
+  },
+};
 export const onNavigateToOntologyArgType: ArgTypes = {
   onNavigateToOntology: {
     required: false,


### PR DESCRIPTION
- Adds a new callback to the searchResultsListWidget named OnNavigateToSearchResult
- It is optional, and the default is None
- If provided, the result title will be a link. Otherwise, the title remains as a string literal
- Clicking on it calls the user-provided callback

<img width="1267" height="157" alt="tss-searchResultClickCallback" src="https://github.com/user-attachments/assets/6dc60e50-92ea-4518-94c8-d4505bcbbd1c" />
<img width="845" height="468" alt="tss-searchResultWithLink" src="https://github.com/user-attachments/assets/17ca6312-89ce-49d1-8d9b-0fafb6d2d836" />
